### PR TITLE
Add extras to Layer's metadata

### DIFF
--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -10,6 +10,13 @@ from qtpy.QtWidgets import (
 )
 
 from napari_metadata._axis_type import AxisType
+from napari_metadata._model import (
+    Axis,
+    ChannelAxis,
+    SpaceAxis,
+    TimeAxis,
+    set_layer_axis_names,
+)
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -30,6 +37,14 @@ class AxisNameTypeWidget(QWidget):
         layout.addWidget(self.name)
         layout.addWidget(self.type)
         self.setLayout(layout)
+
+    def to_axis(self) -> Axis:
+        axis_type = self.type.currentText()
+        if axis_type == "channel":
+            return ChannelAxis(name=self.name.text)
+        elif axis_type == "time":
+            return TimeAxis(name=self.name.text)
+        return SpaceAxis(name=self.name.text)
 
 
 class AxesNameTypeWidget(QWidget):
@@ -82,6 +97,11 @@ class AxesNameTypeWidget(QWidget):
         assert len(names) == len(widgets)
         for name, widget in zip(names, widgets):
             widget.name.setText(name)
+        for layer in self._viewer.layers:
+            layer_axis_names = self._viewer.dims.axis_labels[
+                -layer.ndim :  # noqa
+            ]
+            set_layer_axis_names(layer, layer_axis_names)
 
     def axis_widgets(self) -> Tuple[AxisNameTypeWidget, ...]:
         layout = self.layout()

--- a/src/napari_metadata/_model.py
+++ b/src/napari_metadata/_model.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Protocol, Tuple, runtime_checkable
+
+from ._axis_type import AxisType
+from ._space_units import SpaceUnits
+from ._time_units import TimeUnits
+
+if TYPE_CHECKING:
+    from napari.layers import Layer
+
+
+@runtime_checkable
+class Axis(Protocol):
+    name: str
+
+    def get_type(self) -> AxisType:
+        ...
+
+    def get_unit_name(self) -> Optional[str]:
+        ...
+
+
+@dataclass
+class SpaceAxis:
+    name: str
+    unit: SpaceUnits = SpaceUnits.NONE
+
+    def get_type(self) -> AxisType:
+        return AxisType.SPACE
+
+    def get_unit_name(self) -> Optional[str]:
+        return str(self.unit)
+
+
+@dataclass
+class TimeAxis:
+    name: str
+    unit: TimeUnits = TimeUnits.NONE
+
+    def get_type(self) -> AxisType:
+        return AxisType.TIME
+
+    def get_unit_name(self) -> Optional[str]:
+        return str(self.unit)
+
+
+@dataclass
+class ChannelAxis:
+    name: str
+
+    def get_type(self) -> AxisType:
+        return AxisType.CHANNEL
+
+    def get_unit_name(self) -> Optional[str]:
+        return None
+
+
+EXTRA_METADATA_KEY = "napari-metadata-plugin"
+
+
+@dataclass
+class ExtraMetadata:
+    axes: Tuple[Axis, ...]
+    experiment_id: str = ""
+
+    @classmethod
+    def from_layer(cls, layer: "Layer") -> "ExtraMetadata":
+        return ExtraMetadata(
+            axes=tuple(SpaceAxis(name=str(i)) for i in range(layer.ndim)),
+        )
+
+
+def get_layer_extra_metadata(layer: "Layer") -> Optional[ExtraMetadata]:
+    return layer.metadata.get(EXTRA_METADATA_KEY)
+
+
+def get_layer_axis_names(layer: "Layer") -> Tuple[str, ...]:
+    extra_metadata = get_layer_extra_metadata(layer)
+    return tuple(axis.name for axis in extra_metadata.axes)
+
+
+def set_layer_axes(layer: "Layer", axes: Tuple[Axis, ...]) -> None:
+    layer.metadata[EXTRA_METADATA_KEY].axes = axes
+
+
+def set_layer_axis_names(layer: "Layer", names: Tuple[str, ...]) -> None:
+    extra_metadata = get_layer_extra_metadata(layer)
+    if extra_metadata is None:
+        return
+    axes = extra_metadata.axes
+    assert len(axes) == len(names)
+    for axis, name in zip(axes, names):
+        axis.name = name
+
+
+def set_layer_space_unit(layer: "Layer", unit: SpaceUnits) -> None:
+    for axis in layer.metadata[EXTRA_METADATA_KEY].axes:
+        if isinstance(axis, SpaceAxis):
+            axis.unit = unit
+
+
+def set_layer_time_unit(layer: "Layer", unit: TimeUnits) -> None:
+    for axis in layer.metadata[EXTRA_METADATA_KEY].axes:
+        if isinstance(axis, TimeAxis):
+            axis.unit = unit
+
+
+def coerce_layer_extra_metadata(layer: Optional["Layer"]) -> Optional["Layer"]:
+    if layer is None:
+        return None
+    if EXTRA_METADATA_KEY in layer.metadata:
+        if not isinstance(layer.metadata[EXTRA_METADATA_KEY], ExtraMetadata):
+            return None
+    else:
+        layer.metadata[EXTRA_METADATA_KEY] = ExtraMetadata.from_layer(layer)
+    return layer

--- a/src/napari_metadata/_space_units.py
+++ b/src/napari_metadata/_space_units.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import List
+from typing import List, Optional
 
 
 class SpaceUnits(Enum):
@@ -14,6 +14,13 @@ class SpaceUnits(Enum):
 
     def __str__(self) -> str:
         return self.name.lower()
+
+    @classmethod
+    def from_name(cls, name: str) -> Optional["SpaceUnits"]:
+        for m in cls:
+            if str(m) == name:
+                return m
+        return None
 
     @classmethod
     def names(cls) -> List[str]:

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -4,6 +4,7 @@ import numpy as np
 from napari.components import ViewerModel
 
 from napari_metadata import QMetadataWidget
+from napari_metadata._model import get_layer_axis_names
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -152,25 +153,31 @@ def test_remove_only_3d_image(qtbot: "QtBot"):
 def test_set_axis_name(qtbot: "QtBot"):
     viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
     first_axis_widget = widget._axes_widget.axis_widgets()[0]
+    layer = viewer.layers[0]
     new_name = "y"
     assert first_axis_widget.name.text() != new_name
+    assert get_layer_axis_names(layer)[0] != new_name
     assert viewer.dims.axis_labels[0] != new_name
 
     first_axis_widget.name.setText(new_name)
 
     assert viewer.dims.axis_labels[0] == new_name
+    assert get_layer_axis_names(layer)[0] == new_name
 
 
 def test_set_viewer_axis_label(qtbot: "QtBot"):
     viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
     first_axis_widget = widget._axes_widget.axis_widgets()[0]
+    layer = viewer.layers[0]
     new_name = "y"
     assert viewer.dims.axis_labels[0] != new_name
+    assert get_layer_axis_names(layer)[0] != new_name
     assert first_axis_widget.name.text() != new_name
 
     viewer.dims.axis_labels = [new_name, viewer.dims.axis_labels[1]]
 
     assert first_axis_widget.name.text() == new_name
+    assert get_layer_axis_names(layer)[0] == new_name
 
 
 def test_set_space_unit(qtbot: "QtBot"):

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -4,7 +4,10 @@ import numpy as np
 from napari.components import ViewerModel
 
 from napari_metadata import QMetadataWidget
-from napari_metadata._model import get_layer_axis_names
+from napari_metadata._model import (
+    get_layer_axis_names,
+    get_layer_axis_unit_names,
+)
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -183,13 +186,16 @@ def test_set_viewer_axis_label(qtbot: "QtBot"):
 def test_set_space_unit(qtbot: "QtBot"):
     viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
     space_units_widget = widget._spatial_units
+    layer = viewer.layers[0]
     new_unit = "millimeters"
     assert space_units_widget.currentText() != new_unit
+    assert get_layer_axis_unit_names(layer)[0] != new_unit
     assert viewer.scale_bar.unit != new_unit
 
     space_units_widget.setCurrentText(new_unit)
 
     assert viewer.scale_bar.unit == new_unit
+    assert get_layer_axis_unit_names(layer)[0] == new_unit
 
 
 def test_set_viewer_scale_bar_unit(qtbot: "QtBot"):
@@ -236,6 +242,21 @@ def test_set_viewer_scale_bar_unit_to_abbreviation(qtbot: "QtBot"):
     viewer.scale_bar.unit = "mm"
 
     assert space_units_widget.currentText() == "millimeters"
+
+
+def test_set_time_unit(qtbot: "QtBot"):
+    viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
+    time_units_widget = widget._temporal_units
+    name_type_widget = widget._axes_widget.axis_widgets()[0]
+    name_type_widget.type.setCurrentText("time")
+    layer = viewer.layers[0]
+    new_unit = "milliseconds"
+    assert time_units_widget.currentText() != new_unit
+    assert get_layer_axis_unit_names(layer)[0] != new_unit
+
+    time_units_widget.setCurrentText(new_unit)
+
+    assert get_layer_axis_unit_names(layer)[0] == new_unit
 
 
 def test_set_layer_scale(qtbot: "QtBot"):

--- a/src/napari_metadata/_time_units.py
+++ b/src/napari_metadata/_time_units.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import List
+from typing import List, Optional
 
 
 class TimeUnits(Enum):
@@ -13,6 +13,13 @@ class TimeUnits(Enum):
 
     def __str__(self) -> str:
         return self.name.lower()
+
+    @classmethod
+    def from_name(cls, name: str) -> Optional["TimeUnits"]:
+        for m in cls:
+            if str(m) == name:
+                return m
+        return None
 
     @classmethod
     def names(cls) -> List[str]:

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -19,7 +19,13 @@ from qtpy.QtWidgets import (
 
 from napari_metadata._axes_name_type_widget import AxesNameTypeWidget
 from napari_metadata._axes_spacing_widget import AxesSpacingWidget
-from napari_metadata._model import coerce_layer_extra_metadata
+from napari_metadata._model import (
+    coerce_layer_extra_metadata,
+    set_layer_axis_names,
+    set_layer_space_unit,
+    set_layer_time_unit,
+)
+from napari_metadata._space_units import SpaceUnits
 from napari_metadata._spatial_units_combo_box import SpatialUnitsComboBox
 from napari_metadata._time_units import TimeUnits
 
@@ -82,12 +88,16 @@ class QMetadataWidget(QWidget):
 
         self._spatial_units = SpatialUnitsComboBox(napari_viewer)
         self._add_attribute_row("Spatial units", self._spatial_units)
-        # self._spatial_units.currentTextChanged.connect(self._on_spatial_units_changed)
+        self._spatial_units.currentTextChanged.connect(
+            self._update_all_layers_extra_metadata
+        )
 
         self._temporal_units = QComboBox()
         self._temporal_units.addItems(TimeUnits.names())
         self._add_attribute_row("Temporal units", self._temporal_units)
-        # self._temporal_units.currentTextChanged.connect(self._on_temporal_units_changed)
+        self._temporal_units.currentTextChanged.connect(
+            self._update_all_layers_extra_metadata
+        )
 
         layout.addStretch(1)
 
@@ -108,6 +118,19 @@ class QMetadataWidget(QWidget):
         layout.addLayout(view_controls)
 
         self._on_selected_layers_changed()
+
+    def _update_all_layers_extra_metadata(self) -> None:
+        space_unit = SpaceUnits.from_name(self._spatial_units.currentText())
+        time_unit = TimeUnits.from_name(self._temporal_units.currentText())
+        for layer in self.viewer.layers:
+            layer_axis_names = self.viewer.dims.axis_labels[
+                -layer.ndim :  # noqa
+            ]
+            set_layer_axis_names(layer, layer_axis_names)
+            if space_unit is not None:
+                set_layer_space_unit(layer, space_unit)
+            if time_unit is not None:
+                set_layer_time_unit(layer, time_unit)
 
     def _on_show_full_toggled(self) -> None:
         show_full = self._show_full.isChecked()

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import (
 
 from napari_metadata._axes_name_type_widget import AxesNameTypeWidget
 from napari_metadata._axes_spacing_widget import AxesSpacingWidget
+from napari_metadata._model import coerce_layer_extra_metadata
 from napari_metadata._spatial_units_combo_box import SpatialUnitsComboBox
 from napari_metadata._time_units import TimeUnits
 
@@ -81,10 +82,12 @@ class QMetadataWidget(QWidget):
 
         self._spatial_units = SpatialUnitsComboBox(napari_viewer)
         self._add_attribute_row("Spatial units", self._spatial_units)
+        # self._spatial_units.currentTextChanged.connect(self._on_spatial_units_changed)
 
         self._temporal_units = QComboBox()
         self._temporal_units.addItems(TimeUnits.names())
         self._add_attribute_row("Temporal units", self._temporal_units)
+        # self._temporal_units.currentTextChanged.connect(self._on_temporal_units_changed)
 
         layout.addStretch(1)
 
@@ -159,6 +162,8 @@ class QMetadataWidget(QWidget):
             self._selected_layer.events.data.disconnect(
                 self._on_selected_layer_data_changed
             )
+
+        layer = coerce_layer_extra_metadata(layer)
 
         if layer is not None:
             self._name.setText(layer.name)


### PR DESCRIPTION
This adds a key to the top-level of the `Layer.metadata` dictionary, which is used to store a custom dataclass that stores the extra metadata this plugin cares about that napari can't currently handle.

The reason for adding this is to be able to write reader and writer plugin contributions, rather than rely on opening file dialogs from the widget.

Changes to widgets cause these extra metadata values to be updated. However, changes in the metadata do not currently cause widget values to be updated - that will be handled as part of writing a plugin reader.

Closes #14 