### PR TITLE
File size widget

### DIFF
--- a/src/napari_metadata/_file_size.py
+++ b/src/napari_metadata/_file_size.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import os
+import math
+
+
+def get_filesize(path):
+    size_bytes = os.path.getsize(str(path))
+    return size_bytes
+
+
+def magnitude(x):
+    return int(math.log10(x))
+
+
+def generate_text_for_size(size):
+    order = magnitude(size)
+
+    if order <= 2:
+        text = f'{size} bytes'
+    elif order >= 3 and order < 6:
+        text = f'{size / (10**3)} KB'
+    elif order >= 6 and order < 9:
+        text = f'{size / 10**6} MB'
+    else:
+        text = f'{size / 10**9} GB'
+    return text
+
+
+def generate_display_size(path):
+    size = get_filesize(path)
+    text = generate_text_for_size(size)
+
+    return text

--- a/src/napari_metadata/_tests/test_file_size.py
+++ b/src/napari_metadata/_tests/test_file_size.py
@@ -1,0 +1,39 @@
+from napari_metadata._file_size import generate_text_for_size
+
+
+def test_generate_text_for_size():
+    size = 13
+    text = generate_text_for_size(size)
+    assert text == f'13 bytes'
+
+    size = 130
+    text = generate_text_for_size(size)
+    assert text == f'130 bytes'
+
+    size = 1303
+    text = generate_text_for_size(size)
+    assert text == f'1.303 KB'
+
+    size = 13031
+    text = generate_text_for_size(size)
+    assert text == f'13.031 KB'
+
+    size = 130313
+    text = generate_text_for_size(size)
+    assert text == f'130.313 KB'
+
+    size = 1303131
+    text = generate_text_for_size(size)
+    assert text == f'1.303131 MB'
+
+    size = 13031319
+    text = generate_text_for_size(size)
+    assert text == f'13.031319 MB'
+
+    size = 130313190
+    text = generate_text_for_size(size)
+    assert text == f'130.31319 MB'
+
+    size = 1303131900
+    text = generate_text_for_size(size)
+    assert text == f'1.3031319 GB'

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -22,6 +22,8 @@ from napari_metadata._model import (
 from napari_metadata._space_units import SpaceUnits
 from napari_metadata._spatial_units_combo_box import SpatialUnitsComboBox
 from napari_metadata._time_units import TimeUnits
+from napari_metadata._file_size import generate_display_size
+
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -74,6 +76,10 @@ class QMetadataWidget(QWidget):
         self._temporal_units.currentTextChanged.connect(
             self._update_all_layers_extra_metadata
         )
+
+        self._file_size = QLineEdit()
+        self._add_attribute_row("File size", self._file_size)
+        self._file_size.textChanged.connect(self._on_name_changed)
 
         layout.addStretch(1)
 
@@ -170,6 +176,7 @@ class QMetadataWidget(QWidget):
             self._plugin.setText(self._get_plugin_info(layer))
             self._data_shape.setText(str(layer.data.shape))
             self._data_type.setText(str(layer.data.dtype))
+            self._file_size.setText(generate_display_size(layer.source.path))
 
             layer.events.name.connect(self._on_selected_layer_name_changed)
             layer.events.data.connect(self._on_selected_layer_data_changed)


### PR DESCRIPTION
Adding a file size widget to the attributes. 

Remaining tasks:
* [ ] expand functionality for file types (traversing zarr, etc)
* [ ] handle data loaded before passing to nebari (just check in-memory size?)

Open Questions:
* Why does setting a widget as `ReadOnly` make it dissappear from the UI? Seems like `Visible` should do that, not `ReadOnly`?