### PR TITLE
Use a stacked widget to switch between editable and read-only metadata

### DIFF
--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -24,6 +24,7 @@ from napari_metadata._model import (
 )
 from napari_metadata._space_units import SpaceUnits
 from napari_metadata._time_units import TimeUnits
+from napari_metadata._widget_utils import readonly_lineedit
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -168,12 +169,8 @@ class ReadOnlyAxisNameTypeWidget(QWidget):
 
     def __init__(self, parent: Optional["QWidget"]) -> None:
         super().__init__(parent)
-        self.name = QLineEdit()
-        self.name.setReadOnly(True)
-        self.name.setStyleSheet("QLineEdit{" "background: transparent;" "}")
-        self.type = QLineEdit()
-        self.type.setReadOnly(True)
-        self.type.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+        self.name = readonly_lineedit()
+        self.type = readonly_lineedit()
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, Optional, Tuple, cast
 
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
+    QLabel,
     QLayoutItem,
     QLineEdit,
     QVBoxLayout,
@@ -81,9 +83,9 @@ class AxesNameTypeWidget(QWidget):
         self._update_num_axes(dims.ndim)
         if layer is not None:
             names = self._get_layer_axis_names(layer)
-            # TODO: given the current we always need the event to be emitted,
-            # to be sure that the widgets get some values, but this a giant
-            # code smell.
+            # TODO: given the current design we always need the event to be
+            # emitted, to be sure that the widgets get some values, but this
+            # a giant code smell.
             if dims.axis_labels == names:
                 dims.events.axis_labels()
             else:
@@ -161,3 +163,92 @@ class AxesNameTypeWidget(QWidget):
                         space_unit=space_unit,
                         time_unit=time_unit,
                     )
+
+
+class ReadOnlyAxisNameTypeWidget(QWidget):
+    """Shows one axis' name and type."""
+
+    def __init__(self, parent: Optional["QWidget"]) -> None:
+        super().__init__(parent)
+        self.name = QLabel()
+        self.name.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        self.type = QLabel()
+        self.type.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.name)
+        layout.addWidget(self.type)
+        self.setLayout(layout)
+
+
+class ReadOnlyAxesNameTypeWidget(QWidget):
+    """Shows all axes' names and types."""
+
+    def __init__(self, viewer: "ViewerModel") -> None:
+        super().__init__()
+        self._viewer: "ViewerModel" = viewer
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        self._viewer.dims.events.axis_labels.connect(
+            self._on_viewer_dims_axis_labels_changed
+        )
+
+        self.set_selected_layer(None)
+
+    def set_selected_layer(self, layer: Optional["Layer"]) -> None:
+        dims = self._viewer.dims
+        self._update_num_axes(dims.ndim)
+        layer_ndim = 0 if layer is None else layer.ndim
+        ndim_diff = dims.ndim - layer_ndim
+        # TODO: clean up this giant mess.
+        axes = get_layer_axes(layer) if layer is not None else ()
+        for i, widget in enumerate(self.axis_widgets()):
+            widget.setVisible(i >= ndim_diff)
+            if layer is not None and i >= ndim_diff:
+                axis = axes[i - ndim_diff]
+                widget.name.setText(axis.name)
+                widget.type.setText(str(axis.get_type()))
+
+    def _get_layer_axis_names(self, layer: "Layer") -> Tuple[str, ...]:
+        viewer_names = list(self._viewer.dims.axis_labels)
+        layer_names = get_layer_axis_names(layer)
+        viewer_names[-layer.ndim :] = layer_names  # noqa
+        return tuple(viewer_names)
+
+    def _update_num_axes(self, num_axes: int) -> None:
+        num_widgets: int = self.layout().count()
+        # Add any missing widgets.
+        for _ in range(num_axes - num_widgets):
+            widget = ReadOnlyAxisNameTypeWidget(self)
+            self.layout().addWidget(widget)
+        # Remove any unneeded widgets.
+        for i in range(num_widgets - num_axes):
+            item: QLayoutItem = self.layout().takeAt(num_widgets - (i + 1))
+            item.widget().deleteLater()
+
+    def _on_viewer_dims_axis_labels_changed(self) -> None:
+        self._set_axis_names(self._viewer.dims.axis_labels)
+
+    def _set_axis_names(self, names: Tuple[str, ...]) -> None:
+        widgets = self.axis_widgets()
+        assert len(names) == len(widgets)
+        for name, widget in zip(names, widgets):
+            widget.name.setText(name)
+
+    def axis_widgets(self) -> Tuple[ReadOnlyAxisNameTypeWidget, ...]:
+        layout = self.layout()
+        return [
+            cast(ReadOnlyAxisNameTypeWidget, layout.itemAt(i).widget())
+            for i in range(0, layout.count())
+        ]
+
+    def axis_names(self) -> Tuple[str, ...]:
+        return tuple(widget.name.text() for widget in self.axis_widgets())

--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -1,10 +1,8 @@
 from typing import TYPE_CHECKING, Optional, Tuple, cast
 
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
-    QLabel,
     QLayoutItem,
     QLineEdit,
     QVBoxLayout,
@@ -170,14 +168,12 @@ class ReadOnlyAxisNameTypeWidget(QWidget):
 
     def __init__(self, parent: Optional["QWidget"]) -> None:
         super().__init__(parent)
-        self.name = QLabel()
-        self.name.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
-        self.type = QLabel()
-        self.type.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
+        self.name = QLineEdit()
+        self.name.setReadOnly(True)
+        self.name.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+        self.type = QLineEdit()
+        self.type.setReadOnly(True)
+        self.type.setStyleSheet("QLineEdit{" "background: transparent;" "}")
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/napari_metadata/_axes_spacing_widget.py
+++ b/src/napari_metadata/_axes_spacing_widget.py
@@ -5,10 +5,11 @@ from qtpy.QtWidgets import (
     QDoubleSpinBox,
     QHBoxLayout,
     QLayoutItem,
-    QLineEdit,
     QVBoxLayout,
     QWidget,
 )
+
+from napari_metadata._widget_utils import readonly_lineedit
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -20,9 +21,7 @@ class AxisSpacingWidget(QWidget):
 
     def __init__(self, parent: Optional["QWidget"]) -> None:
         super().__init__(parent)
-        self.name = QLineEdit()
-        self.name.setReadOnly(True)
-        self.name.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+        self.name = readonly_lineedit()
 
         self.spacing = QDoubleSpinBox()
         self.spacing.setDecimals(6)
@@ -132,12 +131,8 @@ class ReadOnlyAxisSpacingWidget(QWidget):
 
     def __init__(self, parent: Optional["QWidget"]) -> None:
         super().__init__(parent)
-        self.name = QLineEdit()
-        self.name.setReadOnly(True)
-        self.name.setStyleSheet("QLineEdit{" "background: transparent;" "}")
-        self.spacing = QLineEdit()
-        self.spacing.setReadOnly(True)
-        self.spacing.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+        self.name = readonly_lineedit()
+        self.spacing = readonly_lineedit()
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/napari_metadata/_axes_spacing_widget.py
+++ b/src/napari_metadata/_axes_spacing_widget.py
@@ -122,3 +122,96 @@ class AxesSpacingWidget(QWidget):
         widget = AxisSpacingWidget(self)
         widget.spacing.valueChanged.connect(self._on_pixel_size_changed)
         return widget
+
+
+class ReadOnlyAxisSpacingWidget(QWidget):
+    """Shows one axis' name and spacing."""
+
+    def __init__(self, parent: Optional["QWidget"]) -> None:
+        super().__init__(parent)
+        self.name = QLabel()
+        self.spacing = QLabel()
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.name)
+        layout.addWidget(self.spacing)
+        self.setLayout(layout)
+
+
+class ReadOnlyAxesSpacingWidget(QWidget):
+    """Shows and controls all axes' names and spacing."""
+
+    def __init__(self, viewer: "ViewerModel") -> None:
+        super().__init__()
+        self._viewer: "ViewerModel" = viewer
+        self._layer: Optional["Layer"] = None
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        self._viewer.dims.events.axis_labels.connect(
+            self._on_viewer_dims_axis_labels_changed
+        )
+
+    def set_selected_layer(self, layer: Optional["Layer"]) -> None:
+        dims = self._viewer.dims
+        self._update_num_axes(dims.ndim)
+        self._set_axis_names(dims.axis_labels)
+        layer_ndim = 0 if layer is None else layer.ndim
+        ndim_diff = dims.ndim - layer_ndim
+        for i, widget in enumerate(self._axis_widgets()):
+            widget.setVisible(i >= ndim_diff)
+
+        old_layer = self._layer
+        if old_layer is not None:
+            old_layer.events.scale.disconnect(self._on_layer_scale_changed)
+        if layer is not None:
+            layer.events.scale.connect(self._on_layer_scale_changed)
+        self._layer = layer
+        if self._layer is not None:
+            self._on_layer_scale_changed()
+
+    def _on_viewer_dims_axis_labels_changed(self) -> None:
+        self._set_axis_names(self._viewer.dims.axis_labels)
+
+    def _set_axis_names(self, names: Tuple[str, ...]) -> None:
+        widgets = self._axis_widgets()
+        for name, widget in zip(names, widgets):
+            widget.name.setText(name)
+
+    def _on_layer_scale_changed(self) -> None:
+        assert self._layer is not None
+        scale = self._layer.scale
+        widgets = self._layer_widgets()
+        for s, w in zip(scale, widgets):
+            w.spacing.setText(str(s))
+
+    def _axis_widgets(self) -> Tuple[ReadOnlyAxisSpacingWidget, ...]:
+        layout = self.layout()
+        return [
+            cast(ReadOnlyAxisSpacingWidget, layout.itemAt(i).widget())
+            for i in range(0, layout.count())
+        ]
+
+    def _layer_widgets(self) -> Tuple[ReadOnlyAxisSpacingWidget, ...]:
+        layer = self._layer
+        dims = self._viewer.dims
+        layer_ndim = 0 if layer is None else layer.ndim
+        ndim_diff = dims.ndim - layer_ndim
+        layer_widgets = []
+        for i, widget in enumerate(self._axis_widgets()):
+            if i >= ndim_diff:
+                layer_widgets.append(widget)
+        return tuple(layer_widgets)
+
+    def _update_num_axes(self, num_axes: int) -> None:
+        num_widgets: int = self.layout().count()
+        # Add any missing widgets.
+        for _ in range(num_axes - num_widgets):
+            widget = ReadOnlyAxisSpacingWidget(self)
+            self.layout().addWidget(widget)
+        # Remove any unneeded widgets.
+        for i in range(num_widgets - num_axes):
+            item: QLayoutItem = self.layout().takeAt(num_widgets - (i + 1))
+            item.widget().deleteLater()

--- a/src/napari_metadata/_axes_spacing_widget.py
+++ b/src/napari_metadata/_axes_spacing_widget.py
@@ -4,8 +4,8 @@ from qtpy.QtWidgets import (
     QAbstractSpinBox,
     QDoubleSpinBox,
     QHBoxLayout,
-    QLabel,
     QLayoutItem,
+    QLineEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -20,7 +20,10 @@ class AxisSpacingWidget(QWidget):
 
     def __init__(self, parent: Optional["QWidget"]) -> None:
         super().__init__(parent)
-        self.name = QLabel()
+        self.name = QLineEdit()
+        self.name.setReadOnly(True)
+        self.name.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+
         self.spacing = QDoubleSpinBox()
         self.spacing.setDecimals(6)
         self.spacing.setRange(1e-6, 1e6)
@@ -129,8 +132,12 @@ class ReadOnlyAxisSpacingWidget(QWidget):
 
     def __init__(self, parent: Optional["QWidget"]) -> None:
         super().__init__(parent)
-        self.name = QLabel()
-        self.spacing = QLabel()
+        self.name = QLineEdit()
+        self.name.setReadOnly(True)
+        self.name.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+        self.spacing = QLineEdit()
+        self.spacing.setReadOnly(True)
+        self.spacing.setStyleSheet("QLineEdit{" "background: transparent;" "}")
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
 
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QComboBox,
     QGridLayout,
@@ -187,8 +188,17 @@ class ReadOnlyMetadataWidget(QWidget):
         self._attribute_layout.setContentsMargins(0, 0, 0, 0)
         self._attribute_widget.setLayout(self._attribute_layout)
 
-        self.name = self._add_attribute_row("Layer name")
+        item_label = QLabel("Item")
+        item_label.setStyleSheet("font-weight: bold")
+        self._attribute_layout.addWidget(item_label, 0, 0)
+        value_label = QLabel("Value")
+        value_label.setStyleSheet("font-weight: bold")
+        value_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        self._attribute_layout.addWidget(value_label, 0, 1)
 
+        self.name = self._add_attribute_row("Layer name")
         self.file_path = self._add_attribute_row("File name")
         self.plugin = self._add_attribute_row("Plugin")
         self.data_shape = self._add_attribute_row("Array shape")
@@ -262,8 +272,10 @@ class ReadOnlyMetadataWidget(QWidget):
         layout = self._attribute_widget.layout()
         row = layout.rowCount()
         layout.addWidget(QLabel(name), row, 0)
-        widget = QLineEdit()
-        widget.setReadOnly(True)
+        widget = QLabel()
+        widget.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         layout.addWidget(widget, row, 1)
         return widget
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -33,6 +33,7 @@ from napari_metadata._model import (
 from napari_metadata._space_units import SpaceUnits
 from napari_metadata._spatial_units_combo_box import SpatialUnitsComboBox
 from napari_metadata._time_units import TimeUnits
+from napari_metadata._widget_utils import readonly_lineedit
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -277,9 +278,7 @@ class ReadOnlyMetadataWidget(QWidget):
         row = layout.rowCount()
         layout.addWidget(QLabel(name), row, 0)
         if widget is None:
-            widget = QLineEdit()
-            widget.setReadOnly(True)
-            widget.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+            widget = readonly_lineedit()
         layout.addWidget(widget, row, 1)
         return widget
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -19,6 +19,7 @@ from napari_metadata._model import (
     EXTRA_METADATA_KEY,
     ExtraMetadata,
     coerce_layer_extra_metadata,
+    get_layer_space_unit,
     get_layer_time_unit,
     set_layer_space_unit,
     set_layer_time_unit,
@@ -48,7 +49,7 @@ class EditableMetadataWidget(QWidget):
         self._attribute_widget.setLayout(self._attribute_layout)
 
         self.name = QLineEdit()
-        self._add_attribute_row("Channel name", self.name)
+        self._add_attribute_row("Layer name", self.name)
         self.name.textChanged.connect(self._on_name_changed)
 
         self._axes_widget = AxesNameTypeWidget(viewer)
@@ -241,6 +242,8 @@ class ReadOnlyMetadataWidget(QWidget):
             self.plugin.setText(self._get_plugin_info(layer))
             self.data_shape.setText(str(layer.data.shape))
             self.data_type.setText(str(layer.data.dtype))
+            self.spatial_units.setText(str(get_layer_space_unit(layer)))
+            self.temporal_units.setText(str(get_layer_time_unit(layer)))
 
             layer.events.name.connect(self._on_selected_layer_name_changed)
             layer.events.data.connect(self._on_selected_layer_data_changed)
@@ -248,6 +251,12 @@ class ReadOnlyMetadataWidget(QWidget):
         # TODO: set axes values
 
         self._selected_layer = layer
+
+    def set_spatial_units(self, units: str) -> None:
+        self.spatial_units.setText(units)
+
+    def set_temporal_units(self, units: str) -> None:
+        self.temporal_units.setText(units)
 
     def _add_attribute_row(self, name: str) -> QWidget:
         layout = self._attribute_widget.layout()
@@ -310,6 +319,13 @@ class QMetadataWidget(QStackedWidget):
         )
         self._readonly_widget.close_button.clicked.connect(self._show_editable)
         self.addWidget(self._readonly_widget)
+
+        self._editable_widget._spatial_units.currentTextChanged.connect(
+            self._readonly_widget.set_spatial_units
+        )
+        self._editable_widget._temporal_units.currentTextChanged.connect(
+            self._readonly_widget.set_temporal_units
+        )
 
         self.viewer.layers.selection.events.changed.connect(
             self._on_selected_layers_changed

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -18,7 +18,10 @@ from napari_metadata._axes_name_type_widget import (
     AxesNameTypeWidget,
     ReadOnlyAxesNameTypeWidget,
 )
-from napari_metadata._axes_spacing_widget import AxesSpacingWidget
+from napari_metadata._axes_spacing_widget import (
+    AxesSpacingWidget,
+    ReadOnlyAxesSpacingWidget,
+)
 from napari_metadata._model import (
     EXTRA_METADATA_KEY,
     ExtraMetadata,
@@ -207,12 +210,11 @@ class ReadOnlyMetadataWidget(QWidget):
         self.data_shape = self._add_attribute_row("Array shape")
         self.data_type = self._add_attribute_row("Data type")
 
-        # TODO: handle axes and spacing.
         self._axes_widget = ReadOnlyAxesNameTypeWidget(viewer)
         self._add_attribute_row("Dimensions", self._axes_widget)
 
-        # self._spacing_widget = AxesSpacingWidget(viewer)
-        # self._add_attribute_row("Spacing", self._spacing_widget)
+        self._spacing_widget = ReadOnlyAxesSpacingWidget(viewer)
+        self._add_attribute_row("Spacing", self._spacing_widget)
 
         self.spatial_units = self._add_attribute_row("Spatial units")
         self.temporal_units = self._add_attribute_row("Temporal units")
@@ -262,6 +264,7 @@ class ReadOnlyMetadataWidget(QWidget):
             layer.events.data.connect(self._on_selected_layer_data_changed)
 
         self._axes_widget.set_selected_layer(layer)
+        self._spacing_widget.set_selected_layer(layer)
 
         self._selected_layer = layer
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
 
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QComboBox,
     QGridLayout,
@@ -199,9 +198,6 @@ class ReadOnlyMetadataWidget(QWidget):
         self._attribute_layout.addWidget(item_label, 0, 0)
         value_label = QLabel("Value")
         value_label.setStyleSheet("font-weight: bold")
-        value_label.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-        )
         self._attribute_layout.addWidget(value_label, 0, 1)
 
         self.name = self._add_attribute_row("Layer name")
@@ -281,10 +277,9 @@ class ReadOnlyMetadataWidget(QWidget):
         row = layout.rowCount()
         layout.addWidget(QLabel(name), row, 0)
         if widget is None:
-            widget = QLabel()
-            widget.setTextInteractionFlags(
-                Qt.TextInteractionFlag.TextSelectableByMouse
-            )
+            widget = QLineEdit()
+            widget.setReadOnly(True)
+            widget.setStyleSheet("QLineEdit{" "background: transparent;" "}")
         layout.addWidget(widget, row, 1)
         return widget
 

--- a/src/napari_metadata/_widget_utils.py
+++ b/src/napari_metadata/_widget_utils.py
@@ -1,0 +1,8 @@
+from qtpy.QtWidgets import QLineEdit
+
+
+def readonly_lineedit() -> QLineEdit:
+    widget = QLineEdit()
+    widget.setReadOnly(True)
+    widget.setStyleSheet("QLineEdit{" "background: transparent;" "}")
+    return widget


### PR DESCRIPTION
There's a lot of code duplication here in order to get read-only versions of the widgets. But as I'm planning to do some redesign/refactoring anyway, I think it's worth getting this in and working from there.

This also hides the save and restore default button appropriately when viewing the read-only widget.