### PR TITLE
Simplify plugin data model

### DIFF
--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -147,7 +147,6 @@ class AxesNameTypeWidget(QWidget):
             extras = extra_metadata(layer)
             space_unit = extras.get_space_unit()
             time_unit = extras.get_time_unit()
-            extras = extra_metadata(layer)
             for i in range(layer.ndim):
                 widget = axis_widgets[i + ndim - layer.ndim]
                 extras.axes[i] = widget.to_axis(

--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -15,12 +15,7 @@ from napari_metadata._model import (
     ChannelAxis,
     SpaceAxis,
     TimeAxis,
-    get_layer_axes,
-    get_layer_axis_names,
-    get_layer_extra_metadata,
-    get_layer_space_unit,
-    get_layer_time_unit,
-    set_layer_axis_names,
+    extra_metadata,
 )
 from napari_metadata._space_units import SpaceUnits
 from napari_metadata._time_units import TimeUnits
@@ -75,33 +70,30 @@ class AxesNameTypeWidget(QWidget):
             self._on_viewer_dims_axis_labels_changed
         )
 
-        self.set_selected_layer(None)
-
-    def set_selected_layer(self, layer: Optional["Layer"]) -> None:
+    def set_selected_layer(self, layer: "Layer") -> None:
         dims = self._viewer.dims
         self._update_num_axes(dims.ndim)
-        if layer is not None:
-            names = self._get_layer_axis_names(layer)
-            # TODO: given the current design we always need the event to be
-            # emitted, to be sure that the widgets get some values, but this
-            # a giant code smell.
-            if dims.axis_labels == names:
-                dims.events.axis_labels()
-            else:
-                dims.axis_labels = names
-        layer_ndim = 0 if layer is None else layer.ndim
-        ndim_diff = dims.ndim - layer_ndim
-        # TODO: clean up this giant mess.
-        axes = get_layer_axes(layer) if layer is not None else ()
+
+        names = self._get_layer_axis_names(layer)
+        # TODO: given the current design we always need the event to be
+        # emitted, to be sure that the widgets get some values, but this
+        # a giant code smell.
+        if dims.axis_labels == names:
+            dims.events.axis_labels()
+        else:
+            dims.axis_labels = names
+        ndim_diff = dims.ndim - layer.ndim
+
+        extras = extra_metadata(layer)
         for i, widget in enumerate(self.axis_widgets()):
             widget.setVisible(i >= ndim_diff)
-            if layer is not None and i >= ndim_diff:
-                axis = axes[i - ndim_diff]
+            if i >= ndim_diff:
+                axis = extras.axes[i - ndim_diff]
                 widget.type.setCurrentText(str(axis.get_type()))
 
     def _get_layer_axis_names(self, layer: "Layer") -> Tuple[str, ...]:
         viewer_names = list(self._viewer.dims.axis_labels)
-        layer_names = get_layer_axis_names(layer)
+        layer_names = extra_metadata(layer).get_axis_names()
         viewer_names[-layer.ndim :] = layer_names  # noqa
         return tuple(viewer_names)
 
@@ -123,18 +115,17 @@ class AxesNameTypeWidget(QWidget):
         return widget
 
     def _on_viewer_dims_axis_labels_changed(self) -> None:
-        self._set_axis_names(self._viewer.dims.axis_labels)
-
-    def _set_axis_names(self, names: Tuple[str, ...]) -> None:
         widgets = self.axis_widgets()
+        names = self._viewer.dims.axis_labels
         assert len(names) == len(widgets)
         for name, widget in zip(names, widgets):
             widget.name.setText(name)
         for layer in self._viewer.layers:
-            layer_axis_names = self._viewer.dims.axis_labels[
-                -layer.ndim :  # noqa
-            ]
-            set_layer_axis_names(layer, layer_axis_names)
+            if extras := extra_metadata(layer):
+                axis_names = self._viewer.dims.axis_labels[
+                    -layer.ndim :  # noqa
+                ]
+                extras.set_axis_names(axis_names)
 
     def axis_widgets(self) -> Tuple[AxisNameTypeWidget, ...]:
         layout = self.layout()
@@ -153,15 +144,16 @@ class AxesNameTypeWidget(QWidget):
         axis_widgets = self.axis_widgets()
         ndim = len(axis_widgets)
         for layer in self._viewer.layers:
-            space_unit = get_layer_space_unit(layer)
-            time_unit = get_layer_time_unit(layer)
-            if extras := get_layer_extra_metadata(layer):
-                for i in range(layer.ndim):
-                    widget = axis_widgets[i + ndim - layer.ndim]
-                    extras.axes[i] = widget.to_axis(
-                        space_unit=space_unit,
-                        time_unit=time_unit,
-                    )
+            extras = extra_metadata(layer)
+            space_unit = extras.get_space_unit()
+            time_unit = extras.get_time_unit()
+            extras = extra_metadata(layer)
+            for i in range(layer.ndim):
+                widget = axis_widgets[i + ndim - layer.ndim]
+                extras.axes[i] = widget.to_axis(
+                    space_unit=space_unit,
+                    time_unit=time_unit,
+                )
 
 
 class ReadOnlyAxisNameTypeWidget(QWidget):
@@ -194,27 +186,17 @@ class ReadOnlyAxesNameTypeWidget(QWidget):
             self._on_viewer_dims_axis_labels_changed
         )
 
-        self.set_selected_layer(None)
-
-    def set_selected_layer(self, layer: Optional["Layer"]) -> None:
+    def set_selected_layer(self, layer: "Layer") -> None:
         dims = self._viewer.dims
         self._update_num_axes(dims.ndim)
-        layer_ndim = 0 if layer is None else layer.ndim
-        ndim_diff = dims.ndim - layer_ndim
-        # TODO: clean up this giant mess.
-        axes = get_layer_axes(layer) if layer is not None else ()
-        for i, widget in enumerate(self.axis_widgets()):
+        ndim_diff = dims.ndim - layer.ndim
+        extras = extra_metadata(layer)
+        for i, widget in enumerate(self._axis_widgets()):
             widget.setVisible(i >= ndim_diff)
-            if layer is not None and i >= ndim_diff:
-                axis = axes[i - ndim_diff]
+            if i >= ndim_diff:
+                axis = extras.axes[i - ndim_diff]
                 widget.name.setText(axis.name)
                 widget.type.setText(str(axis.get_type()))
-
-    def _get_layer_axis_names(self, layer: "Layer") -> Tuple[str, ...]:
-        viewer_names = list(self._viewer.dims.axis_labels)
-        layer_names = get_layer_axis_names(layer)
-        viewer_names[-layer.ndim :] = layer_names  # noqa
-        return tuple(viewer_names)
 
     def _update_num_axes(self, num_axes: int) -> None:
         num_widgets: int = self.layout().count()
@@ -231,17 +213,15 @@ class ReadOnlyAxesNameTypeWidget(QWidget):
         self._set_axis_names(self._viewer.dims.axis_labels)
 
     def _set_axis_names(self, names: Tuple[str, ...]) -> None:
-        widgets = self.axis_widgets()
+        widgets = self._axis_widgets()
+        names = self._viewer.dims.axis_labels
         assert len(names) == len(widgets)
         for name, widget in zip(names, widgets):
             widget.name.setText(name)
 
-    def axis_widgets(self) -> Tuple[ReadOnlyAxisNameTypeWidget, ...]:
+    def _axis_widgets(self) -> Tuple[ReadOnlyAxisNameTypeWidget, ...]:
         layout = self.layout()
-        return [
+        return tuple(
             cast(ReadOnlyAxisNameTypeWidget, layout.itemAt(i).widget())
             for i in range(0, layout.count())
-        ]
-
-    def axis_names(self) -> Tuple[str, ...]:
-        return tuple(widget.name.text() for widget in self.axis_widgets())
+        )

--- a/src/napari_metadata/_model.py
+++ b/src/napari_metadata/_model.py
@@ -67,7 +67,7 @@ class ChannelAxis:
 EXTRA_METADATA_KEY = "napari-metadata-plugin"
 
 
-@dataclass
+@dataclass(frozen=True)
 class OriginalMetadata:
     axes: Tuple[Axis]
     name: Optional[str]
@@ -79,119 +79,55 @@ class ExtraMetadata:
     axes: List[Axis]
     original: Optional[OriginalMetadata] = None
 
+    def get_axis_names(self) -> Tuple[str, ...]:
+        return tuple(axis.name for axis in self.axes)
 
-def get_layer_extra_metadata(layer: "Layer") -> Optional[ExtraMetadata]:
+    def set_axis_names(self, names: Tuple[str, ...]) -> None:
+        assert len(self.axes) == len(names)
+        for axis, name in zip(self.axes, names):
+            axis.name = name
+
+    def get_space_unit(self) -> SpaceUnits:
+        units = tuple(
+            axis.unit for axis in self.axes if isinstance(axis, SpaceAxis)
+        )
+        return units[0] if len(set(units)) == 1 else SpaceUnits.NONE
+
+    def set_space_unit(self, unit: SpaceUnits) -> None:
+        for axis in self.axes:
+            if isinstance(axis, SpaceAxis):
+                axis.unit = unit
+
+    def get_time_unit(self) -> TimeUnits:
+        units = tuple(
+            axis.unit for axis in self.axes if isinstance(axis, TimeAxis)
+        )
+        return units[0] if len(set(units)) == 1 else TimeUnits.NONE
+
+    def set_time_unit(self, unit: TimeUnits) -> None:
+        for axis in self.axes:
+            if isinstance(axis, TimeAxis):
+                axis.unit = unit
+
+
+def extra_metadata(layer: "Layer") -> Optional[ExtraMetadata]:
     return layer.metadata.get(EXTRA_METADATA_KEY)
 
 
-def get_layer_axes(layer: "Layer") -> Tuple[Axis, ...]:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return ()
-    return tuple(extra_metadata.axes)
-
-
-def get_layer_axis_types(layer: "Layer") -> Tuple[AxisType, ...]:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return ()
-    return tuple(axis.get_type() for axis in extra_metadata.axes)
-
-
-def get_layer_axis_names(layer: "Layer") -> Tuple[str, ...]:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return ()
-    return tuple(axis.name for axis in extra_metadata.axes)
-
-
-def get_layer_axis_unit_names(layer: "Layer") -> Tuple[str, ...]:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return ()
-    return tuple(axis.get_unit_name() for axis in extra_metadata.axes)
-
-
-def get_layer_space_unit(layer: "Layer") -> SpaceUnits:
-    space_axis_units = tuple(
-        axis.unit
-        for axis in get_layer_axes(layer)
-        if isinstance(axis, SpaceAxis)
-    )
-    return (
-        space_axis_units[0]
-        if len(set(space_axis_units)) == 1
-        else SpaceUnits.NONE
-    )
-
-
-# TODO: implementaton is almost the same as space, so refactor
-# or overload/template the typing.
-def get_layer_time_unit(layer: "Layer") -> TimeUnits:
-    time_axis_units = tuple(
-        axis.unit
-        for axis in get_layer_axes(layer)
-        if isinstance(axis, TimeAxis)
-    )
-    return (
-        time_axis_units[0]
-        if len(set(time_axis_units)) == 1
-        else TimeUnits.NONE
-    )
-
-
-def set_layer_axes(layer: "Layer", axes: Tuple[Axis, ...]) -> None:
-    layer.metadata[EXTRA_METADATA_KEY].axes = axes
-
-
-def set_layer_axis_names(layer: "Layer", names: Tuple[str, ...]) -> None:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return
-    axes = extra_metadata.axes
-    assert len(axes) == len(names)
-    for axis, name in zip(axes, names):
-        axis.name = name
-
-
-def set_layer_space_unit(layer: "Layer", unit: SpaceUnits) -> None:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return
-    for axis in layer.metadata[EXTRA_METADATA_KEY].axes:
-        if isinstance(axis, SpaceAxis):
-            axis.unit = unit
-
-
-def set_layer_time_unit(layer: "Layer", unit: TimeUnits) -> None:
-    extra_metadata = get_layer_extra_metadata(layer)
-    if extra_metadata is None:
-        return
-    for axis in layer.metadata[EXTRA_METADATA_KEY].axes:
-        if isinstance(axis, TimeAxis):
-            axis.unit = unit
-
-
-def coerce_layer_extra_metadata(
-    viewer: "ViewerModel", layer: Optional["Layer"]
-) -> Optional["Layer"]:
-    if layer is None:
-        return None
+def coerce_extra_metadata(viewer: "ViewerModel", layer: "Layer") -> None:
     if EXTRA_METADATA_KEY in layer.metadata:
-        if not isinstance(layer.metadata[EXTRA_METADATA_KEY], ExtraMetadata):
-            return None
-    else:
-        axes = [
-            SpaceAxis(name=name)
-            for name in viewer.dims.axis_labels[-layer.ndim :]  # noqa
-        ]
-        original = OriginalMetadata(
-            axes=tuple(deepcopy(axes)),
-            name=layer.name,
-            scale=tuple(layer.scale),
-        )
-        layer.metadata[EXTRA_METADATA_KEY] = ExtraMetadata(
-            axes=axes,
-            original=original,
-        )
-    return layer
+        assert isinstance(layer.metadata[EXTRA_METADATA_KEY], ExtraMetadata)
+        return
+    axes = [
+        SpaceAxis(name=name)
+        for name in viewer.dims.axis_labels[-layer.ndim :]  # noqa
+    ]
+    original = OriginalMetadata(
+        axes=tuple(deepcopy(axes)),
+        name=layer.name,
+        scale=tuple(layer.scale),
+    )
+    layer.metadata[EXTRA_METADATA_KEY] = ExtraMetadata(
+        axes=axes,
+        original=original,
+    )

--- a/src/napari_metadata/_reader.py
+++ b/src/napari_metadata/_reader.py
@@ -191,12 +191,13 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                 # MOD: this plugin provides somewhere to put the axes
                 # and some extra metadata.
                 axes = get_axes(node.metadata)
+                scale = (
+                    tuple(metadata["scale"]) if "scale" in metadata else None
+                )
                 original_meta = OriginalMetadata(
                     axes=deepcopy(axes),
                     name=metadata.get("name"),
-                    scale=tuple(metadata["scale"])
-                    if "scale" in metadata
-                    else None,
+                    scale=tuple(scale),
                 )
                 extra_meta = ExtraMetadata(
                     axes=axes,

--- a/src/napari_metadata/_spatial_units_combo_box.py
+++ b/src/napari_metadata/_spatial_units_combo_box.py
@@ -1,9 +1,9 @@
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 
 from pint import Unit, UnitRegistry
 from qtpy.QtWidgets import QComboBox
 
-from napari_metadata._model import get_layer_space_unit
+from napari_metadata._model import extra_metadata
 from napari_metadata._space_units import SpaceUnits
 
 if TYPE_CHECKING:
@@ -33,12 +33,11 @@ class SpatialUnitsComboBox(QComboBox):
 
         self._on_units_changed()
 
-    def set_selected_layer(self, layer: Optional["Layer"]) -> None:
-        if layer is not None:
-            unit = get_layer_space_unit(layer)
-            self._viewer.scale_bar.unit = (
-                str(unit) if unit != SpaceUnits.NONE else None
-            )
+    def set_selected_layer(self, layer: "Layer") -> None:
+        unit = extra_metadata(layer).get_space_unit()
+        self._viewer.scale_bar.unit = (
+            str(unit) if unit != SpaceUnits.NONE else None
+        )
 
     def _on_units_changed(self) -> None:
         text = self.currentText()

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -21,15 +21,7 @@ from napari_metadata._axes_spacing_widget import (
     AxesSpacingWidget,
     ReadOnlyAxesSpacingWidget,
 )
-from napari_metadata._model import (
-    EXTRA_METADATA_KEY,
-    ExtraMetadata,
-    coerce_layer_extra_metadata,
-    get_layer_space_unit,
-    get_layer_time_unit,
-    set_layer_space_unit,
-    set_layer_time_unit,
-)
+from napari_metadata._model import coerce_extra_metadata, extra_metadata
 from napari_metadata._space_units import SpaceUnits
 from napari_metadata._spatial_units_combo_box import SpatialUnitsComboBox
 from napari_metadata._time_units import TimeUnits
@@ -123,15 +115,14 @@ class EditableMetadataWidget(QWidget):
             )
 
         if layer is not None:
-            layer.events.name.connect(self._on_selected_layer_name_changed)
-
-        self._spatial_units.set_selected_layer(layer)
-        self._axes_widget.set_selected_layer(layer)
-        self._spacing_widget.set_selected_layer(layer)
-        if layer is not None:
+            self._spatial_units.set_selected_layer(layer)
+            self._axes_widget.set_selected_layer(layer)
             self.name.setText(layer.name)
-            time_unit = str(get_layer_time_unit(layer))
+            layer.events.name.connect(self._on_selected_layer_name_changed)
+            time_unit = str(extra_metadata(layer).get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
+
+        self._spacing_widget.set_selected_layer(layer)
 
         self._selected_layer = layer
 
@@ -146,37 +137,40 @@ class EditableMetadataWidget(QWidget):
         self.name.setText(event.source.name)
 
     def _on_name_changed(self) -> None:
-        if layer := _get_selected_layer(self._viewer):
-            layer.name = self.name.text()
+        if self._selected_layer is not None:
+            self._selected_layer.name = self.name.text()
 
-    def _on_spatial_units_changed(self):
+    def _on_spatial_units_changed(self) -> None:
         space_unit = SpaceUnits.from_name(self._spatial_units.currentText())
         if space_unit is None:
             space_unit = SpaceUnits.NONE
         for layer in self._viewer.layers:
-            set_layer_space_unit(layer, space_unit)
+            if extras := extra_metadata(layer):
+                extras.set_space_unit(space_unit)
 
-    def _on_temporal_units_changed(self):
+    def _on_temporal_units_changed(self) -> None:
         time_unit = TimeUnits.from_name(self._temporal_units.currentText())
         if time_unit is None:
             time_unit = TimeUnits.NONE
         for layer in self._viewer.layers:
-            set_layer_time_unit(layer, time_unit)
+            if extras := extra_metadata(layer):
+                extras.set_time_unit(time_unit)
 
     def _on_restore_clicked(self) -> None:
-        if layer := _get_selected_layer(self._viewer):
-            metadata: ExtraMetadata = layer.metadata[EXTRA_METADATA_KEY]
-            if original := metadata.original:
-                metadata.axes = list(deepcopy(original.axes))
-                if name := original.name:
-                    layer.name = name
-                if scale := original.scale:
-                    layer.scale = scale
-                # TODO: refactor with _on_selected_layers_changed
-                self._spatial_units.set_selected_layer(layer)
-                self._axes_widget.set_selected_layer(layer)
-                time_unit = str(get_layer_time_unit(layer))
-                self._temporal_units.setCurrentText(time_unit)
+        assert self._selected_layer is not None
+        layer = self._selected_layer
+        extras = extra_metadata(layer)
+        if original := extras.original:
+            extras.axes = list(deepcopy(original.axes))
+            if name := original.name:
+                layer.name = name
+            if scale := original.scale:
+                layer.scale = scale
+            # TODO: refactor with _on_selected_layers_changed
+            self._spatial_units.set_selected_layer(layer)
+            self._axes_widget.set_selected_layer(layer)
+            time_unit = str(extra_metadata(layer).get_time_unit())
+            self._temporal_units.setCurrentText(time_unit)
 
 
 class ReadOnlyMetadataWidget(QWidget):
@@ -254,13 +248,15 @@ class ReadOnlyMetadataWidget(QWidget):
             self.plugin.setText(self._get_plugin_info(layer))
             self.data_shape.setText(str(layer.data.shape))
             self.data_type.setText(str(layer.data.dtype))
-            self.spatial_units.setText(str(get_layer_space_unit(layer)))
-            self.temporal_units.setText(str(get_layer_time_unit(layer)))
+            extras = extra_metadata(layer)
+            self.spatial_units.setText(str(extras.get_space_unit()))
+            self.temporal_units.setText(str(extras.get_time_unit()))
 
             layer.events.name.connect(self._on_selected_layer_name_changed)
             layer.events.data.connect(self._on_selected_layer_data_changed)
 
-        self._axes_widget.set_selected_layer(layer)
+            self._axes_widget.set_selected_layer(layer)
+
         self._spacing_widget.set_selected_layer(layer)
 
         self._selected_layer = layer
@@ -274,11 +270,11 @@ class ReadOnlyMetadataWidget(QWidget):
     def _add_attribute_row(
         self, name: str, widget: Optional[QWidget] = None
     ) -> QWidget:
+        if widget is None:
+            widget = readonly_lineedit()
         layout = self._attribute_widget.layout()
         row = layout.rowCount()
         layout.addWidget(QLabel(name), row, 0)
-        if widget is None:
-            widget = readonly_lineedit()
         layout.addWidget(widget, row, 1)
         return widget
 
@@ -298,15 +294,6 @@ class ReadOnlyMetadataWidget(QWidget):
             if source.sample is None
             else str(source.sample)
         )
-
-
-class ReadOnlyAxisTypeWidget(QWidget):
-    def __init__(self, viewer: "ViewerModel") -> None:
-        super().__init__()
-
-        layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(layout)
 
 
 class InfoWidget(QWidget):
@@ -366,7 +353,9 @@ class QMetadataWidget(QStackedWidget):
         self.setCurrentWidget(self._editable_widget)
 
     def _on_selected_layers_changed(self) -> None:
-        layer = _get_selected_layer(self.viewer)
+        layer = None
+        if len(self.viewer.layers.selection) == 1:
+            layer = next(iter(self.viewer.layers.selection))
 
         if layer is None:
             self.setCurrentWidget(self._info_widget)
@@ -378,10 +367,9 @@ class QMetadataWidget(QStackedWidget):
         if layer == self._selected_layer:
             return
 
-        layer = coerce_layer_extra_metadata(self.viewer, layer)
+        if layer is not None:
+            coerce_extra_metadata(self.viewer, layer)
 
-        # TODO: readonly first since editable may make changes to the napari
-        # data model (e.g. axis_labels).
         self._readonly_widget.set_selected_layer(layer)
         self._editable_widget.set_selected_layer(layer)
 
@@ -392,8 +380,3 @@ class QMetadataWidget(QStackedWidget):
         # viewer for tests.
         if window := getattr(self.viewer, "window", None):
             window.remove_dock_widget(self)
-
-
-def _get_selected_layer(viewer: "ViewerModel") -> Optional["Layer"]:
-    selection = viewer.layers.selection
-    return next(iter(selection)) if len(selection) > 0 else None

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -97,8 +97,6 @@ class EditableMetadataWidget(QWidget):
         control_layout.addStretch(1)
         self.cancel_button = QPushButton("Cancel")
         control_layout.addWidget(self.cancel_button)
-        # TODO: save is in designs, but unclear if we should really
-        # allow in-place saving given napari reader/writer model.
         self._save_button = QPushButton("Save")
         self._save_button.setEnabled(False)
         control_layout.addWidget(self._save_button)
@@ -133,7 +131,6 @@ class EditableMetadataWidget(QWidget):
         layout.addWidget(widget, row, 1)
 
     def _on_selected_layer_name_changed(self, event) -> None:
-        # TODO: find a more reliable way to do this.
         self.name.setText(event.source.name)
 
     def _on_name_changed(self) -> None:
@@ -141,20 +138,20 @@ class EditableMetadataWidget(QWidget):
             self._selected_layer.name = self.name.text()
 
     def _on_spatial_units_changed(self) -> None:
-        space_unit = SpaceUnits.from_name(self._spatial_units.currentText())
-        if space_unit is None:
-            space_unit = SpaceUnits.NONE
+        unit = SpaceUnits.from_name(self._spatial_units.currentText())
+        if unit is None:
+            unit = SpaceUnits.NONE
         for layer in self._viewer.layers:
             if extras := extra_metadata(layer):
-                extras.set_space_unit(space_unit)
+                extras.set_space_unit(unit)
 
     def _on_temporal_units_changed(self) -> None:
-        time_unit = TimeUnits.from_name(self._temporal_units.currentText())
-        if time_unit is None:
-            time_unit = TimeUnits.NONE
+        unit = TimeUnits.from_name(self._temporal_units.currentText())
+        if unit is None:
+            unit = TimeUnits.NONE
         for layer in self._viewer.layers:
             if extras := extra_metadata(layer):
-                extras.set_time_unit(time_unit)
+                extras.set_time_unit(unit)
 
     def _on_restore_clicked(self) -> None:
         assert self._selected_layer is not None
@@ -166,7 +163,6 @@ class EditableMetadataWidget(QWidget):
                 layer.name = name
             if scale := original.scale:
                 layer.scale = scale
-            # TODO: refactor with _on_selected_layers_changed
             self._spatial_units.set_selected_layer(layer)
             self._axes_widget.set_selected_layer(layer)
             time_unit = str(extra_metadata(layer).get_time_unit())
@@ -279,7 +275,6 @@ class ReadOnlyMetadataWidget(QWidget):
         return widget
 
     def _on_selected_layer_name_changed(self, event) -> None:
-        # TODO: find a more reliable way to do this.
         self.name.setText(event.source.name)
 
     def _on_selected_layer_data_changed(self, event) -> None:

--- a/src/napari_metadata/_widget_utils.py
+++ b/src/napari_metadata/_widget_utils.py
@@ -1,4 +1,6 @@
-from qtpy.QtWidgets import QLineEdit
+from typing import Callable
+
+from qtpy.QtWidgets import QLayout, QLayoutItem, QLineEdit, QWidget
 
 
 def readonly_lineedit() -> QLineEdit:
@@ -6,3 +8,17 @@ def readonly_lineedit() -> QLineEdit:
     widget.setReadOnly(True)
     widget.setStyleSheet("QLineEdit{" "background: transparent;" "}")
     return widget
+
+
+def update_num_widgets(
+    *, layout: QLayout, desired_num: int, widget_factory: Callable[[], QWidget]
+) -> None:
+    current_num: int = layout.count()
+    # Add any missing widgets.
+    for _ in range(desired_num - current_num):
+        widget = widget_factory()
+        layout.addWidget(widget)
+    # Remove any unneeded widgets.
+    for i in range(current_num - desired_num):
+        item: QLayoutItem = layout.takeAt(current_num - (i + 1))
+        item.widget().deleteLater()


### PR DESCRIPTION
This change simplifies the plugin's data model module by reducing the number of functions. It also refactors some shared code between the widgets, though there is still plenty of repetition.

Closes #32 