### PR TITLE
Save metadata in-place in limited cases

### DIFF
--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -389,7 +389,7 @@ def test_add_image_with_existing_metadata(qtbot: "QtBot"):
     assert widget._editable_widget._temporal_units.currentText() == "second"
 
 
-def test_save_button_disabled(qtbot: "QtBot"):
+def test_save_button_disabled_with_arbitrary_image(qtbot: "QtBot"):
     viewer = ViewerModel()
     widget = make_metadata_widget(qtbot, viewer)
 
@@ -398,7 +398,25 @@ def test_save_button_disabled(qtbot: "QtBot"):
     assert not widget._editable_widget._save_button.isEnabled()
 
 
-def test_save_button_enabled(qtbot: "QtBot", path):
+def test_save_button_disabled_with_ome_zarr_read_by_builtin(
+    qtbot: "QtBot", path
+):
+    pm = npe2.PluginManager.instance()
+    pm.register(npe2.PluginManifest.from_distribution("napari"))
+    viewer = ViewerModel()
+    widget = make_metadata_widget(qtbot, viewer)
+    image = Image(np.zeros((4, 3)))
+    data, metadata, _ = image.as_layer_data_tuple()
+    write_image(path, data, metadata)
+
+    viewer.open(path, plugin="napari")
+
+    assert not widget._editable_widget._save_button.isEnabled()
+
+
+def test_save_button_enabled_with_ome_zarr_read_with_this_plugin(
+    qtbot: "QtBot", path
+):
     pm = npe2.PluginManager.instance()
     pm.register(npe2.PluginManifest.from_distribution("napari-metadata"))
     viewer = ViewerModel()

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -121,9 +121,16 @@ class EditableMetadataWidget(QWidget):
             time_unit = str(extra_metadata(layer).get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
 
-        self._save_button.setEnabled(
-            layer is not None and writable_image_group(layer) is not None
-        )
+            try:
+                _ = writable_image_group(layer)
+                self._save_button.setEnabled(True)
+                self._save_button.setToolTip("Overwrite metadata file")
+            except ValueError as e:
+                readonly_reason = str(e)
+                self._save_button.setEnabled(False)
+                self._save_button.setToolTip(
+                    "Read-only metadata because " + readonly_reason
+                )
 
         self._spacing_widget.set_selected_layer(layer)
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -26,6 +26,7 @@ from napari_metadata._space_units import SpaceUnits
 from napari_metadata._spatial_units_combo_box import SpatialUnitsComboBox
 from napari_metadata._time_units import TimeUnits
 from napari_metadata._widget_utils import readonly_lineedit
+from napari_metadata._writer import overwrite_metadata, writable_image_group
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -98,7 +99,7 @@ class EditableMetadataWidget(QWidget):
         self.cancel_button = QPushButton("Cancel")
         control_layout.addWidget(self.cancel_button)
         self._save_button = QPushButton("Save")
-        self._save_button.setEnabled(False)
+        self._save_button.clicked.connect(self._on_save_clicked)
         control_layout.addWidget(self._save_button)
 
         layout.addWidget(self._control_widget)
@@ -119,6 +120,10 @@ class EditableMetadataWidget(QWidget):
             layer.events.name.connect(self._on_selected_layer_name_changed)
             time_unit = str(extra_metadata(layer).get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
+
+        self._save_button.setEnabled(
+            layer is not None and writable_image_group(layer) is not None
+        )
 
         self._spacing_widget.set_selected_layer(layer)
 
@@ -167,6 +172,10 @@ class EditableMetadataWidget(QWidget):
             self._axes_widget.set_selected_layer(layer)
             time_unit = str(extra_metadata(layer).get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
+
+    def _on_save_clicked(self) -> None:
+        assert self._selected_layer is not None
+        overwrite_metadata(self._selected_layer)
 
 
 class ReadOnlyMetadataWidget(QWidget):

--- a/src/napari_metadata/_writer.py
+++ b/src/napari_metadata/_writer.py
@@ -1,13 +1,24 @@
 import os
-from typing import Any, Dict, List, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 import numpy as np
 import zarr
 from npe2.types import ArrayLike
 from ome_zarr.io import parse_url
-from ome_zarr.writer import write_multiscale
+from ome_zarr.writer import write_multiscale, write_multiscales_metadata
 
 from ._model import EXTRA_METADATA_KEY, Axis
+
+if TYPE_CHECKING:
+    from napari.layers import Layer
+
+
+@dataclass
+class OmeMetadata:
+    name: str
+    axes: List[Dict[str, str]]
+    transforms: List[List[Dict[str, Any]]]
 
 
 def write_image(
@@ -19,6 +30,74 @@ def write_image(
     store = parse_url(path, mode="w").store
     root = zarr.group(store=store)
 
+    data = data if isinstance(data, Sequence) else [data]
+    metadata = multiscales_metadata(data, attributes)
+
+    write_multiscale(
+        pyramid=data,
+        group=root,
+        name=metadata.name,
+        axes=metadata.axes,
+        coordinate_transformations=metadata.transforms,
+    )
+
+    return [path]
+
+
+def writable_image_group(layer: "Layer") -> Optional[zarr.Group]:
+    source = layer.source
+    reader = source.reader_plugin
+    # We need write access to the zarr group that was read with this plugin.
+    if reader != "napari-metadata":
+        return
+    path = source.path
+    if path is None:
+        return
+    location = parse_url(path, mode="w")
+    if location is None:
+        return
+    return zarr.group(store=location.store)
+
+
+def overwrite_metadata(layer: "Layer") -> None:
+    group = writable_image_group(layer)
+    if group is None:
+        return
+
+    multiscales = group.attrs.get("multiscales")
+    if multiscales is None:
+        return
+
+    # We only expect one multiscale image in the group.
+    if len(multiscales) != 1:
+        return
+
+    # Now everything looks good, lets extract the layer's updated metadata.
+    data, attributes, _ = layer.as_layer_data_tuple()
+    metadata = multiscales_metadata(data, attributes)
+
+    # Update the datasets in place with the updated transforms.
+    # NB: this is potentially lossy since napari does not have a transform
+    # sequence associated with a layer, so we may want to back out here
+    # in some cases.
+    datasets = multiscales[0]["datasets"]
+    assert len(metadata.transforms) == len(datasets)
+    for i in range(len(datasets)):
+        datasets[i]["coordinateTransformations"] = metadata.transforms[i]
+
+    write_multiscales_metadata(
+        group=group,
+        datasets=datasets,
+        name=metadata.name,
+        axes=metadata.axes,
+    )
+
+
+def multiscales_metadata(
+    data: ArrayLike, attributes: Dict[str, Any]
+) -> OmeMetadata:
+    data = data if isinstance(data, Sequence) else [data]
+
     if extras := attributes["metadata"].get(EXTRA_METADATA_KEY):
         axes = [axis_to_ome(axis) for axis in extras.axes]
     else:
@@ -27,15 +106,13 @@ def write_image(
         # https://github.com/ome/ome-zarr-py/issues/249
         # so use space as the most sensible default.
         axes = [
-            {"name": str(i), "type": "space"} for i in range(len(data.shape))
+            {"name": str(i), "type": "space"}
+            for i in range(len(data[0].shape))
         ]
 
     name = attributes["name"]
 
-    multiscale_data = data if isinstance(data, Sequence) else [data]
-    scale_factors = [
-        np.divide(multiscale_data[0].shape, d.shape) for d in multiscale_data
-    ]
+    scale_factors = [np.divide(data[0].shape, d.shape) for d in data]
 
     transforms = [
         [
@@ -51,15 +128,11 @@ def write_image(
         for scale_factor in scale_factors
     ]
 
-    write_multiscale(
-        pyramid=multiscale_data,
-        group=root,
-        axes=axes,
-        coordinate_transformations=transforms,
+    return OmeMetadata(
         name=name,
+        axes=axes,
+        transforms=transforms,
     )
-
-    return [path]
 
 
 def axis_to_ome(axis: Axis) -> Dict[str, str]:


### PR DESCRIPTION
This enables the save button and makes it overwrite the existing metadata file associated with the layer. The motivation is to allow metadata changes that don't require rewriting all the layer data, which could be achieved through the standard *Save selected layer ...* option in napari.

But it's also a potentially dangerous/lossy operation, so it is only enabled if all the following conditions hold.

1\. The layer was read with this plugin. This way we know it's an ome-zarr, we know what file to overwrite (the multiscale image group's zattrs), and can do so with ome-zarr's `write_multiscales_metadata` function.

2\. The layer's file path is writable. I'm assuming this won't typically apply for ome-zarr stored on remote cloud services like S3.

3\. The number of axes is the same in the layer and original file. In particular, `napari-ome-zarr` splits multi-channel images into multiple layers.

In the case that it is not supported, the tooltip of the save button gives a reason why.