### PR TITLE
Only enable restore defaults when metadata is different to original

### DIFF
--- a/src/napari_metadata/_model.py
+++ b/src/napari_metadata/_model.py
@@ -131,3 +131,20 @@ def coerce_extra_metadata(viewer: "ViewerModel", layer: "Layer") -> None:
         axes=axes,
         original=original,
     )
+
+
+def is_metadata_equal_to_original(layer: Optional["Layer"]) -> bool:
+    if layer is None:
+        return False
+    extras = extra_metadata(layer)
+    if extras is None:
+        return False
+    if extras.original is None:
+        return False
+    if tuple(extras.axes) != extras.original.axes:
+        return False
+    if tuple(layer.scale) != extras.original.scale:
+        return False
+    if layer.name != extras.original.name:
+        return False
+    return True

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -327,6 +327,7 @@ def test_restore_defaults(qtbot: "QtBot"):
         widget._editable_widget._temporal_units.currentText() != "nanosecond"
     )
 
+    widget._editable_widget._restore_defaults.setEnabled(True)
     widget._editable_widget._restore_defaults.click()
 
     assert layer.name == metadata.original.name


### PR DESCRIPTION
This updates the enabled state of the restore defaults button anytime anything the editable metadata widget cares about changes. Some of these changes are connected to widget signals, while others are connected to napari model events. Would be nice to have a central place (e.g. the plugin model) to observe for these changes, but this should be good enough for now.

Closes #24.