### PR TITLE
Fix non-image layers

### DIFF
--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -409,11 +409,7 @@ def _layer_data_shape(layer: "Layer") -> str:
     if hasattr(data, "shape"):
         return str(data.shape)
     if isinstance(data, Sequence):
-        return str(
-            len(
-                data,
-            )
-        )
+        return f"{(len(data),)}"
     return "Unknown"
 
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -303,10 +303,10 @@ class ReadOnlyMetadataWidget(QWidget):
     def _on_selected_layer_name_changed(self, event) -> None:
         self.name.setText(event.source.name)
 
-    def _on_selected_layer_data_changed(self, event) -> None:
-        data = event.value
-        self.data_shape.setText(str(data.shape))
-        self.data_type.setText(str(data.dtype))
+    def _on_selected_layer_data_changed(self) -> None:
+        assert (layer := self._selected_layer)
+        self.data_shape.setText(_layer_data_shape(layer))
+        self.data_type.setText(_layer_data_dtype(layer))
 
 
 class InfoWidget(QWidget):


### PR DESCRIPTION
This adds a parametrized test for all layer types in napari. Some of these failed for fairly trivial reasons, so I fixed the issues and the plugin now has basic support for all layer types.

Closes #28