### PR TITLE
Show axis and scale bar when showing widget

### DIFF
--- a/examples/cells-3d.py
+++ b/examples/cells-3d.py
@@ -2,10 +2,6 @@ import napari
 
 viewer = napari.Viewer()
 
-viewer.axes.colored = False
-viewer.axes.visible = True
-viewer.scale_bar.visible = True
-
 viewer.open_sample(plugin="napari-metadata", sample="cells-3d")
 viewer.window.add_plugin_dock_widget(plugin_name="napari-metadata")
 

--- a/examples/cells-mixed-dim.py
+++ b/examples/cells-mixed-dim.py
@@ -2,10 +2,6 @@ import napari
 
 viewer = napari.Viewer()
 
-viewer.axes.colored = False
-viewer.axes.visible = True
-viewer.scale_bar.visible = True
-
 viewer.open_sample(plugin="napari-metadata", sample="nuclei-md")
 viewer.window.add_plugin_dock_widget(plugin_name="napari-metadata")
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, Sequence
 
+from qtpy.QtGui import QShowEvent
 from qtpy.QtWidgets import (
     QComboBox,
     QGridLayout,
@@ -358,6 +359,12 @@ class MetadataWidget(QStackedWidget):
         )
 
         self._on_selected_layers_changed()
+
+    def showEvent(self, event: QShowEvent) -> None:
+        self._viewer.axes.colored = False
+        self._viewer.axes.visible = True
+        self._viewer.scale_bar.visible = True
+        return super().showEvent(event)
 
     def _show_readonly(self) -> None:
         self.setCurrentWidget(self._readonly_widget)


### PR DESCRIPTION
This shows the axes and scale bar overlay on the canvas whenever the widget is shown. This adds convenience since a large part of this widget is related to what is shown on those. This might be a minor annoyance to some users who want these to be non-visible, but they can still use the napari built-in controls to turn them off.