### PR TITLE
Add translation control for each dimension

### DIFF
--- a/src/napari_metadata/_axes_spacing_widget.py
+++ b/src/napari_metadata/_axes_spacing_widget.py
@@ -1,15 +1,13 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from qtpy.QtWidgets import (
     QAbstractSpinBox,
     QDoubleSpinBox,
     QGridLayout,
-    QHBoxLayout,
-    QVBoxLayout,
     QWidget,
 )
 
-from napari_metadata._widget_utils import readonly_lineedit, update_num_widgets
+from napari_metadata._widget_utils import readonly_lineedit
 
 if TYPE_CHECKING:
     from napari.components import ViewerModel
@@ -94,6 +92,7 @@ class AxesSpacingWidget(QWidget):
         self._layer = layer
         if self._layer is not None:
             self._on_layer_scale_changed()
+            self._on_layer_translate_changed()
 
     def _update_num_widgets(self, desired_num: int) -> None:
         current_num = len(self._widgets)
@@ -154,30 +153,46 @@ class AxesSpacingWidget(QWidget):
         return widget
 
 
-class ReadOnlyAxisSpacingWidget(QWidget):
-    """Shows one axis' name and spacing."""
+class ReadOnlyAxisTransformWidgets:
+    """Contains one axis' transform widgets."""
 
-    def __init__(self, parent: Optional["QWidget"]) -> None:
-        super().__init__(parent)
+    def __init__(self) -> None:
         self.name = readonly_lineedit()
         self.spacing = readonly_lineedit()
+        self.translate = readonly_lineedit()
 
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.name)
-        layout.addWidget(self.spacing)
-        self.setLayout(layout)
+    def append_to_grid_layout(self, layout: QGridLayout) -> None:
+        row = layout.count()
+        layout.addWidget(self.name, row, 0)
+        layout.addWidget(self.spacing, row, 1)
+        layout.addWidget(self.translate, row, 2)
+
+    def remove_from_grid_layout(self, layout: QGridLayout) -> None:
+        for w in (self.name, self.spacing, self.translate):
+            layout.removeWidget(w)
+
+    def setVisible(self, visible: bool) -> None:
+        for w in (self.name, self.spacing, self.translate):
+            w.setVisible(visible)
 
 
 class ReadOnlyAxesSpacingWidget(QWidget):
-    """Shows and controls all axes' names and spacing."""
+    """Shows and controls all axes' transform parameters."""
 
     def __init__(self, viewer: "ViewerModel") -> None:
         super().__init__()
         self._viewer: "ViewerModel" = viewer
         self._layer: Optional["Layer"] = None
-        layout = QVBoxLayout()
+        self._widgets: List[AxisTransformWidgets] = []
+
+        layout = QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
+
+        # Header
+        layout.addWidget(readonly_lineedit(), 0, 0)
+        layout.addWidget(readonly_lineedit("Scale"), 0, 1)
+        layout.addWidget(readonly_lineedit("Translate"), 0, 2)
+
         self.setLayout(layout)
 
         self._viewer.dims.events.axis_labels.connect(
@@ -186,11 +201,7 @@ class ReadOnlyAxesSpacingWidget(QWidget):
 
     def set_selected_layer(self, layer: Optional["Layer"]) -> None:
         dims = self._viewer.dims
-        update_num_widgets(
-            layout=self.layout(),
-            desired_num=dims.ndim,
-            widget_factory=lambda: ReadOnlyAxisSpacingWidget(self),
-        )
+        self._update_num_widgets(dims.ndim)
 
         self._set_axis_names(dims.axis_labels)
         layer_ndim = 0 if layer is None else layer.ndim
@@ -201,11 +212,28 @@ class ReadOnlyAxesSpacingWidget(QWidget):
         old_layer = self._layer
         if old_layer is not None:
             old_layer.events.scale.disconnect(self._on_layer_scale_changed)
+            old_layer.events.translate.disconnect(
+                self._on_layer_translate_changed
+            )
         if layer is not None:
             layer.events.scale.connect(self._on_layer_scale_changed)
+            layer.events.translate.connect(self._on_layer_translate_changed)
         self._layer = layer
         if self._layer is not None:
             self._on_layer_scale_changed()
+            self._on_layer_translate_changed()
+
+    def _update_num_widgets(self, desired_num: int) -> None:
+        current_num = len(self._widgets)
+        # Add any missing widgets.
+        for _ in range(desired_num - current_num):
+            widget = ReadOnlyAxisTransformWidgets()
+            widget.append_to_grid_layout(self.layout())
+            self._widgets.append(widget)
+        # Remove any unneeded widgets.
+        for _ in range(current_num - 1, desired_num - 1, -1):
+            widget = self._widgets.pop()
+            widget.remove_from_grid_layout(self.layout())
 
     def _on_viewer_dims_axis_labels_changed(self) -> None:
         self._set_axis_names(self._viewer.dims.axis_labels)
@@ -222,18 +250,19 @@ class ReadOnlyAxesSpacingWidget(QWidget):
         for s, w in zip(scale, widgets):
             w.spacing.setText(str(s))
 
-    def _axis_widgets(self) -> Tuple[ReadOnlyAxisSpacingWidget, ...]:
-        layout = self.layout()
-        return [
-            cast(ReadOnlyAxisSpacingWidget, layout.itemAt(i).widget())
-            for i in range(0, layout.count())
-        ]
+    def _on_layer_translate_changed(self) -> None:
+        assert self._layer is not None
+        translate = self._layer.translate
+        widgets = self._layer_widgets()
+        for t, w in zip(translate, widgets):
+            w.translate.setText(str(t))
 
-    def _layer_widgets(self) -> Tuple[ReadOnlyAxisSpacingWidget, ...]:
-        layer_ndim = 0 if self._layer is None else self._layer.ndim
-        ndim_diff = self._viewer.dims.ndim - layer_ndim
-        layer_widgets = []
-        for i, widget in enumerate(self._axis_widgets()):
-            if i >= ndim_diff:
-                layer_widgets.append(widget)
-        return tuple(layer_widgets)
+    def _axis_widgets(self) -> Tuple[AxisTransformWidgets, ...]:
+        return tuple(self._widgets)
+
+    def _layer_widgets(self) -> Tuple[AxisTransformWidgets, ...]:
+        return (
+            ()
+            if self._layer is None
+            else tuple(self._widgets[-self._layer.ndim :])  # noqa
+        )

--- a/src/napari_metadata/_axes_spacing_widget.py
+++ b/src/napari_metadata/_axes_spacing_widget.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, Optional, Tuple, cast
+from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 from qtpy.QtWidgets import (
     QAbstractSpinBox,
     QDoubleSpinBox,
+    QGridLayout,
     QHBoxLayout,
     QVBoxLayout,
     QWidget,
@@ -25,22 +26,27 @@ def make_double_spinbox(value: float, *, lower: float) -> QDoubleSpinBox:
     return spinbox
 
 
-class AxisSpacingWidget(QWidget):
-    """Shows and controls one axis' name and spacing."""
+class AxisTransformWidgets:
+    """Contains one axis' name, scale, and translate widgets."""
 
-    def __init__(self, parent: Optional["QWidget"]) -> None:
-        super().__init__(parent)
+    def __init__(self) -> None:
         self.name = readonly_lineedit()
-
         self.spacing = make_double_spinbox(1, lower=1e-6)
         self.translate = make_double_spinbox(0, lower=-1e6)
 
-        layout = QHBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.name)
-        layout.addWidget(self.spacing)
-        layout.addWidget(self.translate)
-        self.setLayout(layout)
+    def append_to_grid_layout(self, layout: QGridLayout) -> None:
+        row = layout.count()
+        layout.addWidget(self.name, row, 0)
+        layout.addWidget(self.spacing, row, 1)
+        layout.addWidget(self.translate, row, 2)
+
+    def remove_from_grid_layout(self, layout: QGridLayout) -> None:
+        for w in (self.name, self.spacing, self.translate):
+            layout.removeWidget(w)
+
+    def setVisible(self, visible: bool) -> None:
+        for w in (self.name, self.spacing, self.translate):
+            w.setVisible(visible)
 
 
 # TODO: reduce redundancy between this class and the AxesNameTypeWidget.
@@ -51,8 +57,15 @@ class AxesSpacingWidget(QWidget):
         super().__init__()
         self._viewer: "ViewerModel" = viewer
         self._layer: Optional["Layer"] = None
-        layout = QVBoxLayout()
+        self._widgets: List[AxisTransformWidgets] = []
+        layout = QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
+
+        # Header
+        layout.addWidget(readonly_lineedit(), 0, 0)
+        layout.addWidget(readonly_lineedit("Scale"), 0, 1)
+        layout.addWidget(readonly_lineedit("Translate"), 0, 2)
+
         self.setLayout(layout)
 
         self._viewer.dims.events.axis_labels.connect(
@@ -61,11 +74,7 @@ class AxesSpacingWidget(QWidget):
 
     def set_selected_layer(self, layer: Optional["Layer"]) -> None:
         dims = self._viewer.dims
-        update_num_widgets(
-            layout=self.layout(),
-            desired_num=dims.ndim,
-            widget_factory=self._make_axis_spacing_widget,
-        )
+        self._update_num_widgets(dims.ndim)
 
         self._set_axis_names(dims.axis_labels)
         layer_ndim = 0 if layer is None else layer.ndim
@@ -85,6 +94,18 @@ class AxesSpacingWidget(QWidget):
         self._layer = layer
         if self._layer is not None:
             self._on_layer_scale_changed()
+
+    def _update_num_widgets(self, desired_num: int) -> None:
+        current_num = len(self._widgets)
+        # Add any missing widgets.
+        for _ in range(desired_num - current_num):
+            widget = self._make_axis_transform_widgets()
+            widget.append_to_grid_layout(self.layout())
+            self._widgets.append(widget)
+        # Remove any unneeded widgets.
+        for _ in range(current_num - 1, desired_num - 1, -1):
+            widget = self._widgets.pop()
+            widget.remove_from_grid_layout(self.layout())
 
     def _on_viewer_dims_axis_labels_changed(self) -> None:
         self._set_axis_names(self._viewer.dims.axis_labels)
@@ -116,24 +137,18 @@ class AxesSpacingWidget(QWidget):
         translate = tuple(w.translate.value() for w in self._layer_widgets())
         self._layer.translate = translate
 
-    def _axis_widgets(self) -> Tuple[AxisSpacingWidget, ...]:
-        layout = self.layout()
-        return [
-            cast(AxisSpacingWidget, layout.itemAt(i).widget())
-            for i in range(0, layout.count())
-        ]
+    def _axis_widgets(self) -> Tuple[AxisTransformWidgets, ...]:
+        return tuple(self._widgets)
 
-    def _layer_widgets(self) -> Tuple[AxisSpacingWidget, ...]:
-        layer_ndim = 0 if self._layer is None else self._layer.ndim
-        ndim_diff = self._viewer.dims.ndim - layer_ndim
-        layer_widgets = []
-        for i, widget in enumerate(self._axis_widgets()):
-            if i >= ndim_diff:
-                layer_widgets.append(widget)
-        return tuple(layer_widgets)
+    def _layer_widgets(self) -> Tuple[AxisTransformWidgets, ...]:
+        return (
+            ()
+            if self._layer is None
+            else tuple(self._widgets[-self._layer.ndim :])  # noqa
+        )
 
-    def _make_axis_spacing_widget(self) -> AxisSpacingWidget:
-        widget = AxisSpacingWidget(self)
+    def _make_axis_transform_widgets(self) -> AxisTransformWidgets:
+        widget = AxisTransformWidgets()
         widget.spacing.valueChanged.connect(self._on_pixel_size_changed)
         widget.translate.valueChanged.connect(self._on_translate_changed)
         return widget

--- a/src/napari_metadata/_axes_spacing_widget.py
+++ b/src/napari_metadata/_axes_spacing_widget.py
@@ -29,6 +29,7 @@ class AxisSpacingWidget(QWidget):
         self.spacing.setStepType(
             QAbstractSpinBox.StepType.AdaptiveDecimalStepType
         )
+        self.spacing.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/napari_metadata/_axes_transform_widget.py
+++ b/src/napari_metadata/_axes_transform_widget.py
@@ -4,6 +4,7 @@ from qtpy.QtWidgets import (
     QAbstractSpinBox,
     QDoubleSpinBox,
     QGridLayout,
+    QLabel,
     QWidget,
 )
 
@@ -48,7 +49,7 @@ class AxisTransformWidgets:
 
 
 # TODO: reduce redundancy between this class and the AxesNameTypeWidget.
-class AxesSpacingWidget(QWidget):
+class AxesTransformWidget(QWidget):
     """Shows and controls all axes' names and spacing."""
 
     def __init__(self, viewer: "ViewerModel") -> None:
@@ -60,9 +61,9 @@ class AxesSpacingWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # Header
-        layout.addWidget(readonly_lineedit(), 0, 0)
-        layout.addWidget(readonly_lineedit("Scale"), 0, 1)
-        layout.addWidget(readonly_lineedit("Translate"), 0, 2)
+        layout.addWidget(QLabel("Name"), 0, 0)
+        layout.addWidget(QLabel("Scale"), 0, 1)
+        layout.addWidget(QLabel("Translate"), 0, 2)
 
         self.setLayout(layout)
 
@@ -176,7 +177,7 @@ class ReadOnlyAxisTransformWidgets:
             w.setVisible(visible)
 
 
-class ReadOnlyAxesSpacingWidget(QWidget):
+class ReadOnlyAxesTransformWidget(QWidget):
     """Shows and controls all axes' transform parameters."""
 
     def __init__(self, viewer: "ViewerModel") -> None:
@@ -189,9 +190,9 @@ class ReadOnlyAxesSpacingWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # Header
-        layout.addWidget(readonly_lineedit(), 0, 0)
-        layout.addWidget(readonly_lineedit("Scale"), 0, 1)
-        layout.addWidget(readonly_lineedit("Translate"), 0, 2)
+        layout.addWidget(QLabel("Name"), 0, 0)
+        layout.addWidget(QLabel("Scale"), 0, 1)
+        layout.addWidget(QLabel("Translate"), 0, 2)
 
         self.setLayout(layout)
 

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -441,7 +441,10 @@ def axis_names(widget: MetadataWidget) -> Tuple[str, ...]:
 def are_axis_widgets_visible(widget: MetadataWidget) -> Tuple[bool, ...]:
     axes_widget = widget._editable_widget._axes_widget
     return tuple(
-        map(lambda w: w.isVisibleTo(widget), axes_widget.axis_widgets())
+        map(
+            lambda row: row.name.isVisibleTo(widget),
+            axes_widget.axis_widgets(),
+        )
     )
 
 

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -303,15 +303,29 @@ def test_set_time_unit(qtbot: "QtBot"):
 def test_set_layer_scale(qtbot: "QtBot"):
     viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
     layer = viewer.layers[0]
-    assert layer.scale[0] == 1
     pixel_width_widget = (
         widget._editable_widget._spacing_widget._axis_widgets()[0].spacing
     )
+    assert layer.scale[0] == pixel_width_widget.value()
     assert pixel_width_widget.value() != 4.5
 
     layer.scale = (4.5, layer.scale[1])
 
     assert pixel_width_widget.value() == 4.5
+
+
+def test_set_layer_translate(qtbot: "QtBot"):
+    viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
+    layer = viewer.layers[0]
+    translate_widget = widget._editable_widget._spacing_widget._axis_widgets()[
+        0
+    ].translate
+    assert layer.translate[0] == translate_widget.value()
+    assert translate_widget.value() != -2
+
+    layer.translate = (-2, layer.translate[1])
+
+    assert translate_widget.value() == -2
 
 
 def test_set_pixel_size(qtbot: "QtBot"):
@@ -320,12 +334,26 @@ def test_set_pixel_size(qtbot: "QtBot"):
     pixel_width_widget = (
         widget._editable_widget._spacing_widget._axis_widgets()[0].spacing
     )
-    assert pixel_width_widget.value() == 1
+    assert pixel_width_widget.value() == layer.scale[0]
     assert layer.scale[0] != 4.5
 
     pixel_width_widget.setValue(4.5)
 
     assert layer.scale[0] == 4.5
+
+
+def test_set_translate(qtbot: "QtBot"):
+    viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
+    layer = viewer.layers[0]
+    translate_widget = widget._editable_widget._spacing_widget._axis_widgets()[
+        0
+    ].translate
+    assert translate_widget.value() == layer.translate[0]
+    assert layer.translate[0] != -2
+
+    translate_widget.setValue(-2)
+
+    assert layer.translate[0] == -2
 
 
 def test_restore_defaults(qtbot: "QtBot"):

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -18,9 +18,9 @@ from napari_metadata._axes_name_type_widget import (
     AxesNameTypeWidget,
     ReadOnlyAxesNameTypeWidget,
 )
-from napari_metadata._axes_spacing_widget import (
-    AxesSpacingWidget,
-    ReadOnlyAxesSpacingWidget,
+from napari_metadata._axes_transform_widget import (
+    AxesTransformWidget,
+    ReadOnlyAxesTransformWidget,
 )
 from napari_metadata._model import (
     coerce_extra_metadata,
@@ -59,7 +59,7 @@ class EditableMetadataWidget(QWidget):
         self._axes_widget = AxesNameTypeWidget(viewer)
         self._add_attribute_row("Dimensions", self._axes_widget)
 
-        self._spacing_widget = AxesSpacingWidget(viewer)
+        self._spacing_widget = AxesTransformWidget(viewer)
         self._add_attribute_row("Transforms", self._spacing_widget)
 
         self._spatial_units = SpatialUnitsComboBox(viewer)
@@ -147,7 +147,9 @@ class EditableMetadataWidget(QWidget):
     def _add_attribute_row(self, name: str, widget: QWidget) -> None:
         layout = self._attribute_widget.layout()
         row = layout.rowCount()
-        layout.addWidget(QLabel(name), row, 0)
+        label = QLabel(name)
+        label.setBuddy(widget)
+        layout.addWidget(label, row, 0)
         layout.addWidget(widget, row, 1)
 
     def _on_selected_layer_name_changed(self, event) -> None:
@@ -227,7 +229,7 @@ class ReadOnlyMetadataWidget(QWidget):
         self._axes_widget = ReadOnlyAxesNameTypeWidget(viewer)
         self._add_attribute_row("Dimensions", self._axes_widget)
 
-        self._spacing_widget = ReadOnlyAxesSpacingWidget(viewer)
+        self._spacing_widget = ReadOnlyAxesTransformWidget(viewer)
         self._add_attribute_row("Transforms", self._spacing_widget)
 
         self.spatial_units = self._add_attribute_row("Space units")
@@ -297,7 +299,9 @@ class ReadOnlyMetadataWidget(QWidget):
             widget = readonly_lineedit()
         layout = self._attribute_widget.layout()
         row = layout.rowCount()
-        layout.addWidget(QLabel(name), row, 0)
+        label = QLabel(name)
+        label.setBuddy(widget)
+        layout.addWidget(label, row, 0)
         layout.addWidget(widget, row, 1)
         return widget
 

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -60,7 +60,7 @@ class EditableMetadataWidget(QWidget):
         self._add_attribute_row("Dimensions", self._axes_widget)
 
         self._spacing_widget = AxesSpacingWidget(viewer)
-        self._add_attribute_row("Spacing", self._spacing_widget)
+        self._add_attribute_row("Transforms", self._spacing_widget)
 
         self._spatial_units = SpatialUnitsComboBox(viewer)
         self._add_attribute_row("Spatial units", self._spatial_units)

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -63,14 +63,14 @@ class EditableMetadataWidget(QWidget):
         self._add_attribute_row("Transforms", self._spacing_widget)
 
         self._spatial_units = SpatialUnitsComboBox(viewer)
-        self._add_attribute_row("Spatial units", self._spatial_units)
+        self._add_attribute_row("Space units", self._spatial_units)
         self._spatial_units.currentTextChanged.connect(
             self._on_spatial_units_changed
         )
 
         self._temporal_units = QComboBox()
         self._temporal_units.addItems(TimeUnits.names())
-        self._add_attribute_row("Temporal units", self._temporal_units)
+        self._add_attribute_row("Time units", self._temporal_units)
         self._temporal_units.currentTextChanged.connect(
             self._on_temporal_units_changed
         )
@@ -228,10 +228,10 @@ class ReadOnlyMetadataWidget(QWidget):
         self._add_attribute_row("Dimensions", self._axes_widget)
 
         self._spacing_widget = ReadOnlyAxesSpacingWidget(viewer)
-        self._add_attribute_row("Spacing", self._spacing_widget)
+        self._add_attribute_row("Transforms", self._spacing_widget)
 
-        self.spatial_units = self._add_attribute_row("Spatial units")
-        self.temporal_units = self._add_attribute_row("Temporal units")
+        self.spatial_units = self._add_attribute_row("Space units")
+        self.temporal_units = self._add_attribute_row("Time units")
 
         # Push control widget to bottom.
         layout.addStretch(1)

--- a/src/napari_metadata/_widget_utils.py
+++ b/src/napari_metadata/_widget_utils.py
@@ -1,10 +1,12 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from qtpy.QtWidgets import QLayout, QLayoutItem, QLineEdit, QWidget
 
 
-def readonly_lineedit() -> QLineEdit:
+def readonly_lineedit(text: Optional[str] = None) -> QLineEdit:
     widget = QLineEdit()
+    if text is not None:
+        widget.setText(text)
     widget.setReadOnly(True)
     widget.setStyleSheet("QLineEdit{" "background: transparent;" "}")
     return widget


### PR DESCRIPTION
This adds similar spinboxes to control the translation/offset of each dimension of a layer. It places them next to the scale spinboxes, though the layout may be improved in the future. There is also some refactoring here to improve code sharing a little, but much more is still needed.

Closes #10 