### PR TITLE
Always coerce extra metadata

### DIFF
--- a/src/napari_metadata/_axes_name_type_widget.py
+++ b/src/napari_metadata/_axes_name_type_widget.py
@@ -8,7 +8,7 @@ from napari_metadata._model import (
     ChannelAxis,
     SpaceAxis,
     TimeAxis,
-    extra_metadata,
+    coerce_extra_metadata,
 )
 from napari_metadata._space_units import SpaceUnits
 from napari_metadata._time_units import TimeUnits
@@ -85,7 +85,7 @@ class AxesNameTypeWidget(QWidget):
             dims.axis_labels = names
         ndim_diff = dims.ndim - layer.ndim
 
-        extras = extra_metadata(layer)
+        extras = coerce_extra_metadata(self._viewer, layer)
         for i, row in enumerate(self._rows):
             set_row_visible(row, i >= ndim_diff)
             if i >= ndim_diff:
@@ -94,7 +94,8 @@ class AxesNameTypeWidget(QWidget):
 
     def _get_layer_axis_names(self, layer: "Layer") -> Tuple[str, ...]:
         viewer_names = list(self._viewer.dims.axis_labels)
-        layer_names = extra_metadata(layer).get_axis_names()
+        extras = coerce_extra_metadata(self._viewer, layer)
+        layer_names = extras.get_axis_names()
         viewer_names[-layer.ndim :] = layer_names  # noqa
         return tuple(viewer_names)
 
@@ -110,11 +111,9 @@ class AxesNameTypeWidget(QWidget):
         for name, row in zip(names, self._rows):
             row.name.setText(name)
         for layer in self._viewer.layers:
-            if extras := extra_metadata(layer):
-                axis_names = self._viewer.dims.axis_labels[
-                    -layer.ndim :  # noqa
-                ]
-                extras.set_axis_names(axis_names)
+            extras = coerce_extra_metadata(self._viewer, layer)
+            axis_names = self._viewer.dims.axis_labels[-layer.ndim :]  # noqa
+            extras.set_axis_names(axis_names)
 
     def axis_widgets(self) -> Tuple[AxisNameTypeRow, ...]:
         return tuple(self._rows)
@@ -129,7 +128,7 @@ class AxesNameTypeWidget(QWidget):
         axis_widgets = self.axis_widgets()
         ndim = len(axis_widgets)
         for layer in self._viewer.layers:
-            extras = extra_metadata(layer)
+            extras = coerce_extra_metadata(self._viewer, layer)
             space_unit = extras.get_space_unit()
             time_unit = extras.get_time_unit()
             for i in range(layer.ndim):
@@ -176,7 +175,7 @@ class ReadOnlyAxesNameTypeWidget(QWidget):
             row_factory=ReadOnlyAxisNameTypeRow,
         )
         ndim_diff = dims.ndim - layer.ndim
-        extras = extra_metadata(layer)
+        extras = coerce_extra_metadata(self._viewer, layer)
         for i, row in enumerate(self._rows):
             set_row_visible(row, i >= ndim_diff)
             if i >= ndim_diff:

--- a/src/napari_metadata/_model.py
+++ b/src/napari_metadata/_model.py
@@ -114,23 +114,24 @@ def extra_metadata(layer: "Layer") -> Optional[ExtraMetadata]:
     return layer.metadata.get(EXTRA_METADATA_KEY)
 
 
-def coerce_extra_metadata(viewer: "ViewerModel", layer: "Layer") -> None:
-    if EXTRA_METADATA_KEY in layer.metadata:
-        assert isinstance(layer.metadata[EXTRA_METADATA_KEY], ExtraMetadata)
-        return
-    axes = [
-        SpaceAxis(name=name)
-        for name in viewer.dims.axis_labels[-layer.ndim :]  # noqa
-    ]
-    original = OriginalMetadata(
-        axes=tuple(deepcopy(axes)),
-        name=layer.name,
-        scale=tuple(layer.scale),
-    )
-    layer.metadata[EXTRA_METADATA_KEY] = ExtraMetadata(
-        axes=axes,
-        original=original,
-    )
+def coerce_extra_metadata(
+    viewer: "ViewerModel", layer: "Layer"
+) -> ExtraMetadata:
+    if EXTRA_METADATA_KEY not in layer.metadata:
+        axes = [
+            SpaceAxis(name=name)
+            for name in viewer.dims.axis_labels[-layer.ndim :]  # noqa
+        ]
+        original = OriginalMetadata(
+            axes=tuple(deepcopy(axes)),
+            name=layer.name,
+            scale=tuple(layer.scale),
+        )
+        layer.metadata[EXTRA_METADATA_KEY] = ExtraMetadata(
+            axes=axes,
+            original=original,
+        )
+    return layer.metadata[EXTRA_METADATA_KEY]
 
 
 def is_metadata_equal_to_original(layer: Optional["Layer"]) -> bool:

--- a/src/napari_metadata/_spatial_units_combo_box.py
+++ b/src/napari_metadata/_spatial_units_combo_box.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict
 from pint import Unit, UnitRegistry
 from qtpy.QtWidgets import QComboBox
 
-from napari_metadata._model import extra_metadata
+from napari_metadata._model import coerce_extra_metadata
 from napari_metadata._space_units import SpaceUnits
 
 if TYPE_CHECKING:
@@ -34,7 +34,8 @@ class SpatialUnitsComboBox(QComboBox):
         self._on_units_changed()
 
     def set_selected_layer(self, layer: "Layer") -> None:
-        unit = extra_metadata(layer).get_space_unit()
+        extras = coerce_extra_metadata(self._viewer, layer)
+        unit = extras.get_space_unit()
         self._viewer.scale_bar.unit = (
             str(unit) if unit != SpaceUnits.NONE else None
         )

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -359,8 +359,8 @@ def test_set_translate(qtbot: "QtBot"):
 def test_restore_defaults(qtbot: "QtBot"):
     viewer, widget = make_viewer_with_one_image_and_widget(qtbot)
     layer = viewer.layers[0]
-    metadata = extra_metadata(layer)
-    metadata.original = OriginalMetadata(
+    extras = extra_metadata(layer)
+    extras.original = OriginalMetadata(
         axes=(
             TimeAxis(name="t", unit=TimeUnits.NANOSECOND),
             SpaceAxis(name="u", unit=SpaceUnits.CENTIMETER),
@@ -368,9 +368,9 @@ def test_restore_defaults(qtbot: "QtBot"):
         name="kermit",
         scale=(2, 3),
     )
-    assert layer.name != metadata.original.name
-    assert tuple(layer.scale) != metadata.original.scale
-    assert tuple(metadata.axes) != metadata.original.axes
+    assert layer.name != extras.original.name
+    assert tuple(layer.scale) != extras.original.scale
+    assert tuple(extras.axes) != extras.original.axes
     assert widget._editable_widget._spatial_units.currentText() != "centimeter"
     assert (
         widget._editable_widget._temporal_units.currentText() != "nanosecond"
@@ -379,9 +379,9 @@ def test_restore_defaults(qtbot: "QtBot"):
     widget._editable_widget._restore_defaults.setEnabled(True)
     widget._editable_widget._restore_defaults.click()
 
-    assert layer.name == metadata.original.name
-    assert tuple(layer.scale) == metadata.original.scale
-    assert tuple(metadata.axes) == metadata.original.axes
+    assert layer.name == extras.original.name
+    assert tuple(layer.scale) == extras.original.scale
+    assert tuple(extras.axes) == extras.original.axes
     assert widget._editable_widget._spatial_units.currentText() == "centimeter"
     assert (
         widget._editable_widget._temporal_units.currentText() == "nanosecond"

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -24,7 +24,6 @@ from napari_metadata._axes_transform_widget import (
 )
 from napari_metadata._model import (
     coerce_extra_metadata,
-    extra_metadata,
     is_metadata_equal_to_original,
 )
 from napari_metadata._space_units import SpaceUnits
@@ -136,7 +135,8 @@ class EditableMetadataWidget(QWidget):
             self.name.setText(layer.name)
             layer.events.name.connect(self._on_selected_layer_name_changed)
             layer.events.scale.connect(self._update_restore_enabled)
-            time_unit = str(extra_metadata(layer).get_time_unit())
+            extras = coerce_extra_metadata(self._viewer, layer)
+            time_unit = str(extras.get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
 
         self._spacing_widget.set_selected_layer(layer)
@@ -165,8 +165,8 @@ class EditableMetadataWidget(QWidget):
         if unit is None:
             unit = SpaceUnits.NONE
         for layer in self._viewer.layers:
-            if extras := extra_metadata(layer):
-                extras.set_space_unit(unit)
+            extras = coerce_extra_metadata(self._viewer, layer)
+            extras.set_space_unit(unit)
         self._update_restore_enabled()
 
     def _on_temporal_units_changed(self) -> None:
@@ -174,14 +174,14 @@ class EditableMetadataWidget(QWidget):
         if unit is None:
             unit = TimeUnits.NONE
         for layer in self._viewer.layers:
-            if extras := extra_metadata(layer):
-                extras.set_time_unit(unit)
+            extras = coerce_extra_metadata(self._viewer, layer)
+            extras.set_time_unit(unit)
         self._update_restore_enabled()
 
     def _on_restore_clicked(self) -> None:
         assert self._selected_layer is not None
         layer = self._selected_layer
-        extras = extra_metadata(layer)
+        extras = coerce_extra_metadata(self._viewer, layer)
         if original := extras.original:
             extras.axes = list(deepcopy(original.axes))
             if name := original.name:
@@ -190,7 +190,7 @@ class EditableMetadataWidget(QWidget):
                 layer.scale = scale
             self._spatial_units.set_selected_layer(layer)
             self._axes_widget.set_selected_layer(layer)
-            time_unit = str(extra_metadata(layer).get_time_unit())
+            time_unit = str(extras.get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
 
     def _update_restore_enabled(self) -> None:
@@ -273,7 +273,7 @@ class ReadOnlyMetadataWidget(QWidget):
             self.plugin.setText(_layer_plugin_info(layer))
             self.data_shape.setText(_layer_data_shape(layer))
             self.data_type.setText(_layer_data_dtype(layer))
-            extras = extra_metadata(layer)
+            extras = coerce_extra_metadata(self._viewer, layer)
             self.spatial_units.setText(str(extras.get_space_unit()))
             self.temporal_units.setText(str(extras.get_time_unit()))
 


### PR DESCRIPTION
This uses `coerce_extra_metadata` instead of `extra_metadata` in the widgets, so that it is always present. This change handles a few cases that would previously result in bugs or strange behavior due to missing extras.

1\. `Layer.metadata` is assigned to an entirely new dictionary. When coming back to the widget, the extras are missing which causes an error.
2\. Units were selected for the first selected layer. Then we selected a different layer, and both layers lost their units (because none is used instead).

Even after this PR, (1) will cause the previous metadata to be lost and we'll just repopulate it with the defaults. We could try to fix this by connecting a callback to `Layer.events.metadata`, but I don't think that's worth the associated trouble and is not a complete fix anyway.

Closes #40