### PR TITLE
Fix restore functionality for translation

### DIFF
--- a/src/napari_metadata/_model.py
+++ b/src/napari_metadata/_model.py
@@ -72,6 +72,7 @@ class OriginalMetadata:
     axes: Tuple[Axis]
     name: Optional[str]
     scale: Optional[Tuple[float, ...]]
+    translate: Optional[Tuple[float, ...]]
 
 
 @dataclass
@@ -126,6 +127,7 @@ def coerce_extra_metadata(
             axes=tuple(deepcopy(axes)),
             name=layer.name,
             scale=tuple(layer.scale),
+            translate=tuple(layer.translate),
         )
         layer.metadata[EXTRA_METADATA_KEY] = ExtraMetadata(
             axes=axes,
@@ -145,6 +147,8 @@ def is_metadata_equal_to_original(layer: Optional["Layer"]) -> bool:
     if tuple(extras.axes) != extras.original.axes:
         return False
     if tuple(layer.scale) != extras.original.scale:
+        return False
+    if tuple(layer.translate) != extras.original.translate:
         return False
     if layer.name != extras.original.name:
         return False

--- a/src/napari_metadata/_reader.py
+++ b/src/napari_metadata/_reader.py
@@ -194,10 +194,16 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                 scale = (
                     tuple(metadata["scale"]) if "scale" in metadata else None
                 )
+                translate = (
+                    tuple(metadata["translate"])
+                    if "translate" in metadata
+                    else None
+                )
                 original_meta = OriginalMetadata(
                     axes=deepcopy(axes),
                     name=metadata.get("name"),
-                    scale=tuple(scale),
+                    scale=scale,
+                    translate=translate,
                 )
                 extra_meta = ExtraMetadata(
                     axes=axes,

--- a/src/napari_metadata/_sample_data.py
+++ b/src/napari_metadata/_sample_data.py
@@ -80,6 +80,7 @@ def _make_metadata(
         name=name,
         axes=tuple(deepcopy(axes)),
         scale=scale,
+        translate=(0,) * len(scale),
     )
     extras = ExtraMetadata(axes=axes, original=original)
     return {

--- a/src/napari_metadata/_tests/test_widget.py
+++ b/src/napari_metadata/_tests/test_widget.py
@@ -367,9 +367,11 @@ def test_restore_defaults(qtbot: "QtBot"):
         ),
         name="kermit",
         scale=(2, 3),
+        translate=(-1, 0.5),
     )
     assert layer.name != extras.original.name
     assert tuple(layer.scale) != extras.original.scale
+    assert tuple(layer.translate) != extras.original.translate
     assert tuple(extras.axes) != extras.original.axes
     assert widget._editable_widget._spatial_units.currentText() != "centimeter"
     assert (
@@ -381,6 +383,7 @@ def test_restore_defaults(qtbot: "QtBot"):
 
     assert layer.name == extras.original.name
     assert tuple(layer.scale) == extras.original.scale
+    assert tuple(layer.translate) == extras.original.translate
     assert tuple(extras.axes) == extras.original.axes
     assert widget._editable_widget._spatial_units.currentText() == "centimeter"
     assert (

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -158,7 +158,6 @@ class EditableMetadataWidget(QWidget):
 
     def _on_selected_layer_name_changed(self, event) -> None:
         self.name.setText(event.source.name)
-        self._update_restore_enabled()
 
     def _on_name_changed(self) -> None:
         if self._selected_layer is not None:

--- a/src/napari_metadata/_widget.py
+++ b/src/napari_metadata/_widget.py
@@ -128,6 +128,9 @@ class EditableMetadataWidget(QWidget):
             self._selected_layer.events.scale.disconnect(
                 self._update_restore_enabled
             )
+            self._selected_layer.events.translate.disconnect(
+                self._update_restore_enabled
+            )
 
         if layer is not None:
             self._spatial_units.set_selected_layer(layer)
@@ -135,6 +138,7 @@ class EditableMetadataWidget(QWidget):
             self.name.setText(layer.name)
             layer.events.name.connect(self._on_selected_layer_name_changed)
             layer.events.scale.connect(self._update_restore_enabled)
+            layer.events.translate.connect(self._update_restore_enabled)
             extras = coerce_extra_metadata(self._viewer, layer)
             time_unit = str(extras.get_time_unit())
             self._temporal_units.setCurrentText(time_unit)
@@ -154,6 +158,7 @@ class EditableMetadataWidget(QWidget):
 
     def _on_selected_layer_name_changed(self, event) -> None:
         self.name.setText(event.source.name)
+        self._update_restore_enabled()
 
     def _on_name_changed(self) -> None:
         if self._selected_layer is not None:
@@ -188,6 +193,8 @@ class EditableMetadataWidget(QWidget):
                 layer.name = name
             if scale := original.scale:
                 layer.scale = scale
+            if translate := original.translate:
+                layer.translate = translate
             self._spatial_units.set_selected_layer(layer)
             self._axes_widget.set_selected_layer(layer)
             time_unit = str(extras.get_time_unit())


### PR DESCRIPTION
This adds the `translate` or offset value to the original metadata, so that value can be restored after editing in the widget. I modified the associated tests to check that happens.