### PR TITLE
Add real sample data from zenodo

### DIFF
--- a/examples/hiPSCs-3d-mip.py
+++ b/examples/hiPSCs-3d-mip.py
@@ -1,0 +1,8 @@
+import napari
+
+viewer = napari.Viewer()
+
+viewer.open_sample(plugin="napari-metadata", sample="hipsc-3d-mip")
+viewer.window.add_plugin_dock_widget(plugin_name="napari-metadata")
+
+napari.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     pint
     pooch
     scikit-image
+    tqdm
     zarr
 
 python_requires = >=3.8

--- a/src/napari_metadata/_reader.py
+++ b/src/napari_metadata/_reader.py
@@ -219,7 +219,7 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                         name = [name] * n_channels
                     for n, m in zip(name, metadata["metadata"]):
                         m[EXTRA_METADATA_KEY] = make_extras(
-                            metadata=m,
+                            metadata=metadata,
                             axes=axes,
                             name=n,
                         )

--- a/src/napari_metadata/_sample_data.py
+++ b/src/napari_metadata/_sample_data.py
@@ -1,7 +1,9 @@
+import os
 from copy import deepcopy
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 import numpy as np
+import pooch
 from skimage.data import cells3d
 
 from napari_metadata._model import (
@@ -11,9 +13,24 @@ from napari_metadata._model import (
     SpaceAxis,
     SpaceUnits,
 )
+from napari_metadata._reader import napari_get_reader
 
 if TYPE_CHECKING:
     from npe2.types import LayerData
+
+
+def read_ome_zarr_hipsc_mip() -> List["LayerData"]:
+    unzip_dir = pooch.retrieve(
+        url="https://zenodo.org/record/7674571/files/"
+        "20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr.zip?"
+        "download=1",
+        known_hash="md5:93722285708d58a36a0a3ee413b2c8a1",
+        processor=pooch.Unzip(),
+        progressbar=True,
+    )
+    zarr_dir = os.path.split(unzip_dir[0])[0]
+    reader = napari_get_reader(zarr_dir)
+    return reader(zarr_dir)
 
 
 def make_nuclei_md_sample_data() -> List["LayerData"]:

--- a/src/napari_metadata/_sample_data.py
+++ b/src/napari_metadata/_sample_data.py
@@ -20,6 +20,14 @@ if TYPE_CHECKING:
 
 
 def read_ome_zarr_hipsc_mip() -> List["LayerData"]:
+    """Downloads and reads a multi-channel 3D MIP of hiPSCs from Zenodo [1]_.
+
+    Notes
+    -----
+    .. [1] Lüthi, Joel. (2023). OME-Zarr 3D hiPSCs with 3D labels & 3D
+       measurements, 2x2 field of views (1.1.0) [Data set]. Zenodo.
+       https://doi.org/10.5281/zenodo.7674571
+    """
     unzip_dir = pooch.retrieve(
         url="https://zenodo.org/record/7674571/files/"
         "20200812-CardiomyocyteDifferentiation14-Cycle1_mip.zarr.zip?"

--- a/src/napari_metadata/_tests/test_reader.py
+++ b/src/napari_metadata/_tests/test_reader.py
@@ -208,7 +208,12 @@ def test_read_multichannel_2d_image_with_extras(rng, path):
     assert read_metadata["translate"] == (-1, 1)
     assert read_metadata["channel_axis"] == 0
 
-    read_extras: ExtraMetadata = read_metadata["metadata"][EXTRA_METADATA_KEY]
+    # One metadata dict for each output layer.
+    assert len(read_metadata["metadata"]) == 2
+    # Check details of the first one.
+    read_extras = read_metadata["metadata"][0][EXTRA_METADATA_KEY]
     assert len(read_extras.axes) == 2
     assert read_extras.axes[0] == extras.axes[1]
     assert read_extras.axes[1] == extras.axes[2]
+    # Check the other is the same.
+    assert read_extras == read_metadata["metadata"][1][EXTRA_METADATA_KEY]

--- a/src/napari_metadata/napari.yaml
+++ b/src/napari_metadata/napari.yaml
@@ -4,7 +4,7 @@ contributions:
   commands:
     - id: napari-metadata.read_ome_zarr_hipsc_mip
       python_name: napari_metadata._sample_data:read_ome_zarr_hipsc_mip
-      title: Load 3D MIP OME-Zarr hiPSCs with labels
+      title: Load 3D MIP of hiPSCs
     - id: napari-metadata.make_cells_3d_sample_data
       python_name: napari_metadata._sample_data:make_cells_3d_sample_data
       title: Load 3D cells with metadata
@@ -22,7 +22,7 @@ contributions:
       title: Write image with metadata
   sample_data:
     - command: napari-metadata.read_ome_zarr_hipsc_mip
-      display_name: hiPSC 3D MIP
+      display_name: hiPSCs 3D MIP
       key: hipsc-3d-mip
     - command: napari-metadata.make_cells_3d_sample_data
       display_name: Cells 3D

--- a/src/napari_metadata/napari.yaml
+++ b/src/napari_metadata/napari.yaml
@@ -2,6 +2,9 @@ name: napari-metadata
 display_name: Layer metadata
 contributions:
   commands:
+    - id: napari-metadata.read_ome_zarr_hipsc_mip
+      python_name: napari_metadata._sample_data:read_ome_zarr_hipsc_mip
+      title: Load 3D MIP OME-Zarr hiPSCs with labels
     - id: napari-metadata.make_cells_3d_sample_data
       python_name: napari_metadata._sample_data:make_cells_3d_sample_data
       title: Load 3D cells with metadata
@@ -18,6 +21,9 @@ contributions:
       python_name: napari_metadata._writer:write_image
       title: Write image with metadata
   sample_data:
+    - command: napari-metadata.read_ome_zarr_hipsc_mip
+      display_name: hiPSC 3D MIP
+      key: hipsc-3d-mip
     - command: napari-metadata.make_cells_3d_sample_data
       display_name: Cells 3D
       key: cells-3d


### PR DESCRIPTION
This adds some real-world sample data from zenodo that contains a MIP of a 3D volume of hiPSCs. It uses `pooch.retrieve` to manage downloading and caching this data, so just uses the general pooch cache.

<img width="776" alt="Screenshot 2023-03-27 at 2 29 26 PM" src="https://user-images.githubusercontent.com/2608297/228071929-421478bc-3a45-418c-81f0-d9b7356ec21e.png">

I used the MIP instead of the full 3D volume to reduce the download size (~100MB instead of ~1GB).

Closes #45