### PR TITLE
Add license for napari-ome-zarr

### DIFF
--- a/src/napari_metadata/_reader.py
+++ b/src/napari_metadata/_reader.py
@@ -1,11 +1,38 @@
-"""This module is a napari plugin.
-It implements the ``napari_get_reader`` hook specification,
-to create a reader plugin.
+""" Defines napari reader contributions that handle extra metadata.
 
-Vendored from v0.5.2 of napari-ome-zarr.
-Modifications are indicated inline.
+The code in this module is vendored from v0.5.2 of napari-ome-zarr.
+Modifications are indicated inline with the `MOD:` prefix.
+The license for the original code from napari-ome-zarr is below.
 
-TODO: proper attribution for this.
+----------------------------
+
+Copyright (c) 2021, OME Team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of napari-ome-zarr nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import logging


### PR DESCRIPTION
This adds a copy of the license associated with napari-ome-zarr from which the code was initially vendored before modification.